### PR TITLE
add direct torrent intake, metadata cache, and explainable autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,32 @@ CC=/usr/bin/clang CXX=/usr/bin/clang++ go install github.com/melqtx/tork/cmd/tor
 Config lives in `~/.tork/`; downloads land in `~/Downloads/tork` (change with
 `tork -d DIR`).
 
+Already have a torrent? Paste its magnet link, bare infohash, local `.torrent`
+path, or `.torrent` URL into the same home search box. To go straight to the
+quiet file preview:
+
+```sh
+tork 'magnet:?xt=urn:btih:…'
+tork ~/Downloads/linux.iso.torrent
+tork 'https://example.org/linux.iso.torrent'
+tork --torrent-url 'https://example.org/download?id=123'
+```
+
+Nothing starts downloading until you confirm it. If a bare hash is still
+finding metadata peers, wait to choose individual files or press enter to queue
+the whole torrent immediately. Once metadata arrives, tork keeps a private
+bounded copy under `~/.tork/metainfo/`, so reopening or resuming that magnet no
+longer depends on finding a metadata peer.
+
+Cache defaults are conservative and can be changed in `~/.tork/config.yaml`:
+
+```yaml
+metadata_cache:
+  enabled: true
+  max_mb: 256
+  max_entries: 512
+```
+
 ## SOCKS5 proxy
 
 For the usual local Tor setup, one command is enough:
@@ -86,14 +112,14 @@ falls back to a direct connection.
 
 ## Keep an eye on it
 
-`tork doctor` is read-only by default and checks config, disk, state, and
-provider reachability. Add `--engine` for an opt-in listener check, `--record`
-to save provider results in `~/.tork/health.json`, or `--proxy-check` to ask the
-Tor Project's check service what egress IP it sees through your configured
-proxy. That proves this explicit HTTP check used the route; it is not a promise
-of anonymity or a claim about your normal connection. Health history contains
-local provider timings plus torrent names and swarm counts; it is never
-uploaded.
+`tork doctor` is read-only by default and checks config, disk, state, cached
+metadata, and provider reachability. Add `--engine` for an opt-in listener
+check, `--record` to save provider results in `~/.tork/health.json`, or
+`--proxy-check` to ask the Tor Project's check service what egress IP it sees
+through your configured proxy. That proves this explicit HTTP check used the
+route; it is not a promise of anonymity or a claim about your normal
+connection. Health history contains local provider timings plus torrent names
+and swarm counts; it is never uploaded.
 
 Automatic checks are off by default. Enable a local daily check with:
 
@@ -117,10 +143,30 @@ manual check.
 
 ## Autopilot (WIP)
 
-Describe what you want and let the cat fetch it:
+Describe what you want and let the cat make a plan:
 
 ```sh
-tork autopilot "all breaking bad seasons 1080p"      # also: --dry-run, -n N, --headless
+tork autopilot "all breaking bad seasons 1080p under 40GB"
+tork autopilot --dry-run --min-seeders 20 "dune 2024 2160p"
+```
+
+Autopilot shows its picks, total known size, reasons, and a summary of rejected
+results before asking to queue anything. Use `-n N` to cap the picks,
+`--max-size 8GB` to cap each download, or `--category movies,anime` to narrow
+provider categories. When the same limit appears in several places, the flag
+wins over the request text, which wins over config defaults. `--headless` skips
+the TUI but still asks before queuing; scripts and cron jobs need `--yes`.
+Decisions stay local in `~/.tork/autopilot.jsonl` so a strange choice can be
+inspected later.
+
+Persistent defaults can live under `autopilot` in `~/.tork/config.yaml`:
+
+```yaml
+autopilot:
+  max_downloads: 3
+  min_seeders: 10
+  max_size_gb: 40
+  allowed_categories: [movies, anime]
 ```
 
 ## Legal

--- a/cmd/tork/main.go
+++ b/cmd/tork/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
@@ -22,6 +23,7 @@ import (
 	"github.com/melqtx/tork/internal/config"
 	"github.com/melqtx/tork/internal/engine"
 	"github.com/melqtx/tork/internal/health"
+	"github.com/melqtx/tork/internal/intake"
 	"github.com/melqtx/tork/internal/provider"
 	"github.com/melqtx/tork/internal/proxy"
 	"github.com/melqtx/tork/internal/state"
@@ -100,20 +102,23 @@ func printHelp() {
 	fmt.Print(`tork - terminal torrent search and download
 
 Usage:
-  tork [--evil] [-d DIR]
-  tork autopilot [--dry-run] [--headless] [--evil] [-n N] [-d DIR] "query"
+  tork [--evil] [-d DIR] [MAGNET | INFOHASH | TORRENT_URL | TORRENT_FILE]
+  tork [--evil] [-d DIR] --torrent-url URL
+  tork autopilot [--dry-run] [--headless] [--yes] [--evil] [-n N] [-d DIR] "query"
   tork doctor [--record] [--engine] [--proxy-check] [-d DIR]
   tork proxy tor|set [SOCKS5_URL]|off|status
   tork --version
 
 Commands:
-  autopilot   search, pick the best sources, and queue them
+  autopilot   search, explain the best choices, then queue them
   doctor      read-only config, disk, state, and provider diagnostic
   proxy       configure or inspect strict SOCKS5 routing
 
 Flags:
   -d, --download-dir DIR   where to save downloads (default: your OS
                            Downloads folder, ~/Downloads/tork)
+      --torrent-url URL    explicit torrent endpoint when its path does not
+                           end in .torrent
       --evil               evil mode: downloads never seed after they finish
                            (applies to new downloads this session only)
 
@@ -345,6 +350,11 @@ func runAutopilot(args []string) error {
 	maxN := fs.Int("n", 0, "max downloads (overrides config)")
 	dryRun := fs.Bool("dry-run", false, "plan only; don't download")
 	headless := fs.Bool("headless", false, "no TUI; print progress until complete")
+	yes := fs.Bool("yes", false, "queue the plan without asking")
+	fs.BoolVar(yes, "y", false, "shorthand for --yes")
+	minSeeders := fs.Int("min-seeders", -1, "minimum seeders (overrides config)")
+	maxSize := fs.String("max-size", "", "largest allowed download, for example 8GB")
+	categories := fs.String("category", "", "comma-separated allowed provider categories")
 	dlDir := fs.String("download-dir", "", "download directory (default: your OS Downloads/tork)")
 	fs.StringVar(dlDir, "d", "", "shorthand for --download-dir")
 	evil := fs.Bool("evil", false, "evil mode: never seed after downloads complete")
@@ -353,7 +363,21 @@ func runAutopilot(args []string) error {
 	}
 	raw := strings.TrimSpace(strings.Join(fs.Args(), " "))
 	if raw == "" {
-		return errors.New(`usage: tork autopilot [-n N] [--dry-run] [--headless] "query"`)
+		return errors.New(`usage: tork autopilot [-n N] [--max-size 8GB] [--dry-run] [--headless] [--yes] "query"`)
+	}
+	var maxSizeBytes int64
+	if strings.TrimSpace(*maxSize) != "" {
+		parsed, parseErr := autopilot.ParseSizeLimit(*maxSize)
+		if parseErr != nil {
+			return errors.New("--max-size must look like 750MB, 8GB, or 1.5TB")
+		}
+		maxSizeBytes = parsed
+	}
+	var allowedCategories []string
+	for _, category := range strings.Split(*categories, ",") {
+		if category = strings.TrimSpace(category); category != "" {
+			allowedCategories = append(allowedCategories, category)
+		}
 	}
 
 	cfg, err := config.Load()
@@ -391,11 +415,27 @@ func runAutopilot(args []string) error {
 	defer stop()
 
 	dep := autopilot.Deps{Cfg: cfg, Agg: agg, Eng: eng, State: st, Providers: providers, Out: os.Stdout}
-	queued, err := dep.Execute(ctx, raw, *dryRun, *maxN)
+	opts := autopilot.Options{
+		DryRun: *dryRun, MaxDownloads: *maxN,
+		MaxSizeBytes: maxSizeBytes, Categories: allowedCategories,
+	}
+	if *minSeeders >= 0 {
+		opts.MinSeeders = *minSeeders
+		opts.OverrideMinSeeders = true
+	}
+	// --headless controls output, not consent: it still confirms on a
+	// terminal and still requires --yes everywhere else.
+	if !*dryRun && !*yes {
+		if !term.IsTerminal(os.Stdin.Fd()) {
+			return errors.New("autopilot needs confirmation; rerun with --yes for non-interactive use")
+		}
+		opts.Confirm = confirmAutopilot
+	}
+	plan, err := dep.Execute(ctx, raw, opts)
 	if err != nil {
 		return err
 	}
-	if *dryRun || len(queued) == 0 {
+	if *dryRun || plan.Queued == 0 {
 		return nil
 	}
 
@@ -426,12 +466,31 @@ func runAutopilot(args []string) error {
 	return st.Save(cfg.StatePath())
 }
 
+func confirmAutopilot(plan autopilot.Plan) bool {
+	fmt.Fprintf(os.Stdout, "\nqueue these %d download(s)? [y/N] ", len(plan.Picks))
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
 func run() error {
 	fs := flag.NewFlagSet("tork", flag.ContinueOnError)
 	dlDir := fs.String("download-dir", "", "download directory (default: your OS Downloads/tork)")
 	fs.StringVar(dlDir, "d", "", "shorthand for --download-dir")
 	evil := fs.Bool("evil", false, "evil mode: never seed after downloads complete")
+	torrentURL := fs.String("torrent-url", "", "explicit .torrent download URL (allows non-.torrent paths)")
 	if err := fs.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+	openTarget, err := resolveOpenTarget(fs.Args(), *torrentURL)
+	if err != nil {
 		return err
 	}
 
@@ -476,11 +535,41 @@ func run() error {
 	stopHealth := maybeCheckHealth(context.Background(), cfg, store, providers, eng, healthWarmup)
 	defer stopHealth()
 
-	p := tea.NewProgram(tui.New(cfg, eng, agg, st, store), tea.WithAltScreen())
+	app := tui.New(cfg, eng, agg, st, store)
+	if openTarget != nil {
+		if err := app.OpenTarget(*openTarget); err != nil {
+			return err
+		}
+	}
+	p := tea.NewProgram(app, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		return err
 	}
 	return st.Save(cfg.StatePath())
+}
+
+func resolveOpenTarget(args []string, explicitURL string) (*intake.Target, error) {
+	if len(args) > 1 || (explicitURL != "" && len(args) != 0) {
+		return nil, errors.New("usage: tork [--evil] [-d DIR] [MAGNET | INFOHASH | TORRENT_URL | TORRENT_FILE]")
+	}
+	if explicitURL != "" {
+		target, err := intake.ExplicitTorrentURL(explicitURL)
+		if err != nil {
+			return nil, err
+		}
+		return &target, nil
+	}
+	if len(args) == 0 {
+		return nil, nil
+	}
+	target, ok, err := intake.DetectCLI(args[0])
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.New("expected a magnet link, infohash, torrent URL, or local torrent file")
+	}
+	return &target, nil
 }
 
 // resumeAll re-adds persisted downloads; bolt piece completion (torrents) and

--- a/cmd/tork/main_test.go
+++ b/cmd/tork/main_test.go
@@ -81,3 +81,22 @@ func TestEntryDataPresentAcceptsPartFile(t *testing.T) {
 		t.Fatal("part file reported missing")
 	}
 }
+
+func TestResolveOpenTargetRejectsConflictingInputs(t *testing.T) {
+	if _, err := resolveOpenTarget([]string{"one", "two"}, ""); err == nil {
+		t.Fatal("accepted multiple positional inputs")
+	}
+	if _, err := resolveOpenTarget([]string{"0123456789abcdef0123456789abcdef01234567"}, "https://example.test/download?id=1"); err == nil {
+		t.Fatal("accepted positional input with --torrent-url")
+	}
+}
+
+func TestResolveOpenTargetAcceptsExplicitAmbiguousURL(t *testing.T) {
+	target, err := resolveOpenTarget(nil, "https://example.test/download?id=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target == nil || target.Value != "https://example.test/download?id=1" {
+		t.Fatalf("target = %+v", target)
+	}
+}

--- a/internal/autopilot/autopilot.go
+++ b/internal/autopilot/autopilot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -55,41 +56,87 @@ type Deps struct {
 	Out       io.Writer
 }
 
-// Execute parses a request, searches all providers, ranks and selects the
-// best downloads, prints a report, and (unless dryRun) resolves magnets and
-// queues them. maxOverride > 0 replaces the configured download cap.
-// It returns the picks that were queued.
-func (d Deps) Execute(ctx context.Context, raw string, dryRun bool, maxOverride int) ([]Pick, error) {
+// Options controls one execution without changing the user's saved defaults.
+type Options struct {
+	DryRun             bool
+	MaxDownloads       int
+	MinSeeders         int
+	OverrideMinSeeders bool
+	MaxSizeBytes       int64
+	Categories         []string
+	Confirm            func(Plan) bool
+}
+
+// Execute parses a request, searches all providers, prints an explainable
+// plan, optionally asks the caller to confirm it, and queues the approved
+// picks. Every decision is appended to the local autopilot history.
+func (d Deps) Execute(ctx context.Context, raw string, opts Options) (Plan, error) {
 	in := ParseIntent(raw)
 	in.MinSeeders = d.Cfg.Autopilot.MinSeeders
 	in.Max = d.Cfg.Autopilot.MaxDownloads
-	if maxOverride > 0 {
-		in.Max = maxOverride
+	if d.Cfg.Autopilot.MaxSizeGB > 0 && in.MaxSizeBytes == 0 {
+		if d.Cfg.Autopilot.MaxSizeGB >= 1<<33 {
+			return Plan{}, fmt.Errorf("autopilot.max_size_gb is too large")
+		}
+		in.MaxSizeBytes = int64(d.Cfg.Autopilot.MaxSizeGB * (1 << 30))
+	}
+	in.Categories = append([]string(nil), d.Cfg.Autopilot.AllowedCategories...)
+	if opts.MaxDownloads > 0 {
+		in.Max = opts.MaxDownloads
+	}
+	if opts.OverrideMinSeeders {
+		in.MinSeeders = opts.MinSeeders
+	}
+	if opts.MaxSizeBytes > 0 {
+		in.MaxSizeBytes = opts.MaxSizeBytes
+	}
+	if len(opts.Categories) > 0 {
+		in.Categories = append([]string(nil), opts.Categories...)
 	}
 
 	fmt.Fprintf(d.Out, "autopilot: %q\n", raw)
-	fmt.Fprintf(d.Out, "  parsed → query=%q  resolution=%s  season=%s  max=%d  min-seeders=%d\n\n",
+	fmt.Fprintf(d.Out, "  plan → query=%q  resolution=%s  season=%s  max=%d  min-seeders=%d",
 		in.Query, resStr(in), seasonStr(in), in.Max, in.MinSeeders)
+	if in.MaxSizeBytes > 0 {
+		fmt.Fprintf(d.Out, "  max-size=%s", formatBytes(in.MaxSizeBytes))
+	}
+	if len(in.Categories) > 0 {
+		fmt.Fprintf(d.Out, "  categories=%s", strings.Join(in.Categories, ","))
+	}
+	fmt.Fprintln(d.Out)
+	fmt.Fprintln(d.Out)
 
 	results := d.gather(ctx, in.Query)
 	fmt.Fprintf(d.Out, "\n%d results gathered\n", len(results))
 
 	known := knownHashes(d.State)
-	picks := Select(results, in, d.Cfg.Ranking, known)
-	if len(picks) == 0 {
+	plan := BuildPlan(results, in, d.Cfg.Ranking, known)
+	if len(plan.Picks) == 0 {
 		fmt.Fprintln(d.Out, "\nno suitable downloads found (try lowering min_seeders or relaxing the query)")
-		return nil, nil
+		printRejections(d.Out, plan.Rejected)
+		plan.Outcome = "no matches"
+		d.record(raw, in, plan)
+		return plan, nil
 	}
-	printPicks(d.Out, picks)
+	printPicks(d.Out, plan.Picks)
+	fmt.Fprintf(d.Out, "  total: %s\n", formatBytes(plan.TotalBytes))
+	printRejections(d.Out, plan.Rejected)
 
-	if dryRun {
+	if opts.DryRun {
 		fmt.Fprintln(d.Out, "\ndry run - nothing queued")
-		return picks, nil
+		plan.Outcome = "dry run"
+		d.record(raw, in, plan)
+		return plan, nil
+	}
+	if opts.Confirm != nil && !opts.Confirm(plan) {
+		fmt.Fprintln(d.Out, "not queued")
+		plan.Outcome = "cancelled"
+		d.record(raw, in, plan)
+		return plan, nil
 	}
 
 	fmt.Fprintln(d.Out, "\nqueuing…")
-	queued := picks[:0]
-	for _, p := range picks {
+	for _, p := range plan.Picks {
 		magnet, err := d.resolve(ctx, p.Result)
 		if err != nil {
 			fmt.Fprintf(d.Out, "  ✗ %s: %s\n", trunc(p.Result.Title, 50), ShortReason(err))
@@ -120,9 +167,25 @@ func (d Deps) Execute(ctx context.Context, raw string, dryRun bool, maxOverride 
 		}
 		d.State.Upsert(entry)
 		fmt.Fprintf(d.Out, "  ✓ %s\n", trunc(p.Result.Title, 60))
-		queued = append(queued, p)
+		plan.Queued++
 	}
-	return queued, d.State.Save(d.Cfg.StatePath())
+	plan.Outcome = "queued"
+	if plan.Queued < len(plan.Picks) {
+		plan.Outcome = "partially queued"
+	}
+	if err := d.State.Save(d.Cfg.StatePath()); err != nil {
+		plan.Outcome = "state save failed"
+		d.record(raw, in, plan)
+		return plan, err
+	}
+	d.record(raw, in, plan)
+	return plan, nil
+}
+
+func (d Deps) record(raw string, in Intent, plan Plan) {
+	if err := appendDecision(d.Cfg.AutopilotHistoryPath(), raw, in, plan); err != nil {
+		fmt.Fprintf(d.Out, "  ! could not save autopilot decision: %s\n", ShortReason(err))
+	}
 }
 
 // gather runs the aggregator to completion, printing per-provider status.
@@ -224,6 +287,40 @@ func printPicks(out io.Writer, picks []Pick) {
 			p.Result.Seeders, p.Score, p.Reason)
 	}
 	tw.Flush()
+}
+
+func printRejections(out io.Writer, rejected map[string]int) {
+	keys := make([]string, 0, len(rejected))
+	for reason, count := range rejected {
+		if count > 0 {
+			keys = append(keys, reason)
+		}
+	}
+	if len(keys) == 0 {
+		return
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, reason := range keys {
+		parts = append(parts, fmt.Sprintf("%d %s", rejected[reason], reason))
+	}
+	fmt.Fprintf(out, "  skipped: %s\n", strings.Join(parts, " · "))
+}
+
+func formatBytes(n int64) string {
+	if n <= 0 {
+		return "size unknown"
+	}
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for q := n / unit; q >= unit && exp < 4; q /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
 func resStr(in Intent) string {

--- a/internal/autopilot/execute_test.go
+++ b/internal/autopilot/execute_test.go
@@ -1,0 +1,91 @@
+package autopilot
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/melqtx/tork/internal/aggregator"
+	"github.com/melqtx/tork/internal/config"
+	"github.com/melqtx/tork/internal/provider"
+	"github.com/melqtx/tork/internal/state"
+)
+
+type planProvider struct{ result provider.Result }
+
+func (planProvider) Name() string { return "plan" }
+
+func (p planProvider) Search(ctx context.Context, _ string, out chan<- provider.Result) error {
+	select {
+	case out <- p.result:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestExecuteDryRunExplainsAndRecordsWithoutQueueing(t *testing.T) {
+	downloads := filepath.Join(t.TempDir(), "Downloads")
+	t.Setenv("XDG_DOWNLOAD_DIR", downloads)
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := planProvider{provider.Result{
+		Title: "Dune 2024 2160p WEB", Provider: "plan", Category: "Movies",
+		Size: "7 GiB", SizeBytes: 7 << 30, Seeders: 100,
+		Magnet: hashMagnet("abababababababababababababababababababab"),
+	}}
+	var out bytes.Buffer
+	st := &state.State{}
+	d := Deps{
+		Cfg: cfg, Agg: aggregator.New([]provider.Provider{p}, cfg.SearchTimeout(), 1),
+		State: st, Out: &out,
+	}
+	plan, err := d.Execute(context.Background(), "dune 2024 2160p under 8GB", Options{DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Outcome != "dry run" || len(plan.Picks) != 1 || plan.Queued != 0 || len(st.Entries) != 0 {
+		t.Fatalf("plan = %+v, state = %+v", plan, st)
+	}
+	for _, want := range []string{"max-size=8.0 GiB", "selected 1 download", "total: 7.0 GiB", "dry run - nothing queued"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output omitted %q:\n%s", want, out.String())
+		}
+	}
+	data, err := os.ReadFile(cfg.AutopilotHistoryPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte(`"outcome":"dry run"`)) {
+		t.Fatalf("history omitted dry-run outcome: %s", data)
+	}
+}
+
+func TestExecuteCancelledPlanNeverTouchesEngine(t *testing.T) {
+	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := planProvider{provider.Result{
+		Title: "Safe Pick 1080p", Provider: "plan", SizeBytes: 1 << 30,
+		Seeders: 100, Magnet: hashMagnet("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"),
+	}}
+	st := &state.State{}
+	d := Deps{
+		Cfg: cfg, Agg: aggregator.New([]provider.Provider{p}, cfg.SearchTimeout(), 1),
+		State: st, Out: &bytes.Buffer{}, Eng: nil,
+	}
+	plan, err := d.Execute(context.Background(), "safe pick 1080p", Options{Confirm: func(Plan) bool { return false }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Outcome != "cancelled" || plan.Queued != 0 || len(st.Entries) != 0 {
+		t.Fatalf("cancelled plan = %+v, state = %+v", plan, st)
+	}
+}

--- a/internal/autopilot/intent.go
+++ b/internal/autopilot/intent.go
@@ -3,7 +3,9 @@
 package autopilot
 
 import (
+	"math"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/melqtx/tork/internal/rank"
@@ -11,12 +13,14 @@ import (
 
 // Intent is the heuristic interpretation of an autopilot request.
 type Intent struct {
-	Query      string          // cleaned search terms
-	WantRes    rank.Resolution // preferred resolution, ResUnknown if unspecified
-	AllSeasons bool            // "all seasons" / "complete" / "every season"
-	Season     int             // specific season, 0 if none
-	MinSeeders int             // from config
-	Max        int             // cap on downloads, from config
+	Query        string          // cleaned search terms
+	WantRes      rank.Resolution // preferred resolution, ResUnknown if unspecified
+	AllSeasons   bool            // "all seasons" / "complete" / "every season"
+	Season       int             // specific season, 0 if none
+	MinSeeders   int             // from config
+	Max          int             // cap on downloads, from config
+	MaxSizeBytes int64           // 0 means unlimited
+	Categories   []string        // optional case-insensitive category allowlist
 }
 
 var (
@@ -26,6 +30,7 @@ var (
 	reSeasonNum    = regexp.MustCompile(`(?i)\bseasons?[ ._]*(\d{1,2})\b`)
 	reSeasonAny    = regexp.MustCompile(`(?i)\bseasons?([ ._]*\d{1,2})?\b`)
 	reResToken     = regexp.MustCompile(`(?i)\b(2160p|4k|uhd|1080p|720p|480p)\b`)
+	reMaxSize      = regexp.MustCompile(`(?i)\b(?:under|max(?:imum)?|up[ ._]+to)\s*(\d+(?:\.\d+)?)\s*(tb|tib|gb|gib|mb|mib)\b`)
 	reWS           = regexp.MustCompile(`\s+`)
 )
 
@@ -36,6 +41,9 @@ func ParseIntent(raw string) Intent {
 
 	tags := rank.Parse(raw)
 	in.WantRes = tags.Resolution
+	if m := reMaxSize.FindStringSubmatch(raw); m != nil {
+		in.MaxSizeBytes, _ = parseSizeParts(m[1], m[2])
+	}
 
 	// Detect season constraints on a resolution-stripped copy so tokens like
 	// "1080p" can't be misread as a season number.
@@ -50,6 +58,7 @@ func ParseIntent(raw string) Intent {
 
 	// Build the search query by stripping constraint + filler tokens.
 	q := reResToken.ReplaceAllString(raw, " ")
+	q = reMaxSize.ReplaceAllString(q, " ")
 	q = reComplete.ReplaceAllString(q, " ")
 	q = reSeasonAny.ReplaceAllString(q, " ") // "season 3", "seasons", "season"
 	q = reFillerTokens.ReplaceAllString(q, " ")
@@ -57,6 +66,39 @@ func ParseIntent(raw string) Intent {
 	in.Query = strings.TrimSpace(q)
 
 	return in
+}
+
+// ParseSizeLimit accepts compact command-line limits such as 750MB, 8gb, or
+// 1.5TiB. Torrent sizes are conventionally binary, so both GB and GiB use a
+// 1024-based multiplier here.
+func ParseSizeLimit(raw string) (int64, error) {
+	m := regexp.MustCompile(`(?i)^\s*(\d+(?:\.\d+)?)\s*(tb|tib|gb|gib|mb|mib)\s*$`).FindStringSubmatch(raw)
+	if m == nil {
+		return 0, strconv.ErrSyntax
+	}
+	return parseSizeParts(m[1], m[2])
+}
+
+func parseSizeParts(number, unit string) (int64, error) {
+	n, err := strconv.ParseFloat(number, 64)
+	if err != nil || n <= 0 {
+		return 0, strconv.ErrSyntax
+	}
+	var mul float64
+	switch strings.ToLower(unit) {
+	case "mb", "mib":
+		mul = 1 << 20
+	case "gb", "gib":
+		mul = 1 << 30
+	case "tb", "tib":
+		mul = 1 << 40
+	default:
+		return 0, strconv.ErrSyntax
+	}
+	if n > float64(math.MaxInt64)/mul {
+		return 0, strconv.ErrRange
+	}
+	return int64(n * mul), nil
 }
 
 func atoi(s string) int {

--- a/internal/autopilot/intent_test.go
+++ b/internal/autopilot/intent_test.go
@@ -36,3 +36,27 @@ func TestParseIntent(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIntentExtractsNaturalSizeLimit(t *testing.T) {
+	in := ParseIntent("grab dune 2024 2160p under 12.5GB")
+	if in.Query != "dune 2024" {
+		t.Fatalf("Query = %q, want dune 2024", in.Query)
+	}
+	want := int64(12.5 * (1 << 30))
+	if in.MaxSizeBytes != want {
+		t.Fatalf("MaxSizeBytes = %d, want %d", in.MaxSizeBytes, want)
+	}
+}
+
+func TestParseSizeLimit(t *testing.T) {
+	got, err := ParseSizeLimit("1.5 GiB")
+	if err != nil || got != int64(1.5*(1<<30)) {
+		t.Fatalf("ParseSizeLimit = %d, %v", got, err)
+	}
+	if _, err := ParseSizeLimit("lots"); err == nil {
+		t.Fatal("ParseSizeLimit accepted a non-size")
+	}
+	if _, err := ParseSizeLimit("999999999999999TB"); err == nil {
+		t.Fatal("ParseSizeLimit accepted an overflowing size")
+	}
+}

--- a/internal/autopilot/report.go
+++ b/internal/autopilot/report.go
@@ -1,0 +1,67 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+type decisionRecord struct {
+	At           time.Time      `json:"at"`
+	Request      string         `json:"request"`
+	Query        string         `json:"query"`
+	Resolution   string         `json:"resolution,omitempty"`
+	Season       string         `json:"season,omitempty"`
+	MinSeeders   int            `json:"min_seeders"`
+	MaxDownloads int            `json:"max_downloads"`
+	MaxSize      int64          `json:"max_size_bytes,omitempty"`
+	Categories   []string       `json:"categories,omitempty"`
+	Picks        []decisionPick `json:"picks,omitempty"`
+	Rejected     map[string]int `json:"rejected,omitempty"`
+	TotalBytes   int64          `json:"total_bytes,omitempty"`
+	Queued       int            `json:"queued"`
+	Outcome      string         `json:"outcome"`
+}
+
+type decisionPick struct {
+	Title    string  `json:"title"`
+	Provider string  `json:"provider"`
+	Size     int64   `json:"size_bytes,omitempty"`
+	Seeders  int     `json:"seeders"`
+	Score    float64 `json:"score"`
+	Reason   string  `json:"reason"`
+}
+
+func appendDecision(path, raw string, in Intent, plan Plan) error {
+	rec := decisionRecord{
+		At:           time.Now().UTC(),
+		Request:      raw,
+		Query:        in.Query,
+		Resolution:   resStr(in),
+		Season:       seasonStr(in),
+		MinSeeders:   in.MinSeeders,
+		MaxDownloads: in.Max,
+		MaxSize:      in.MaxSizeBytes,
+		Categories:   append([]string(nil), in.Categories...),
+		Rejected:     plan.Rejected,
+		TotalBytes:   plan.TotalBytes,
+		Queued:       plan.Queued,
+		Outcome:      plan.Outcome,
+	}
+	for _, p := range plan.Picks {
+		rec.Picks = append(rec.Picks, decisionPick{
+			Title: p.Result.Title, Provider: p.Result.Provider,
+			Size: p.Result.SizeBytes, Seeders: p.Result.Seeders,
+			Score: p.Score, Reason: p.Reason,
+		})
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Chmod(0o600); err != nil {
+		return err
+	}
+	return json.NewEncoder(f).Encode(rec)
+}

--- a/internal/autopilot/report_test.go
+++ b/internal/autopilot/report_test.go
@@ -1,0 +1,39 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/melqtx/tork/internal/provider"
+)
+
+func TestAppendDecisionWritesSmallLocalRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "autopilot.jsonl")
+	plan := Plan{
+		Picks:    []Pick{{Result: provider.Result{Title: "A release", Provider: "test", SizeBytes: 42, Seeders: 9}, Score: 12, Reason: "best available"}},
+		Rejected: map[string]int{"over size limit": 2}, TotalBytes: 42, Outcome: "dry run",
+	}
+	if err := appendDecision(path, "find a thing", Intent{Query: "thing", MinSeeders: 5}, plan); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rec decisionRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("history is not JSONL: %v", err)
+	}
+	if rec.Outcome != "dry run" || len(rec.Picks) != 1 || rec.Picks[0].Title != "A release" {
+		t.Fatalf("record = %+v", rec)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("history mode = %v; want 0600", info.Mode().Perm())
+	}
+}

--- a/internal/autopilot/select.go
+++ b/internal/autopilot/select.go
@@ -3,6 +3,7 @@ package autopilot
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/anacrolix/torrent/metainfo"
 
@@ -16,6 +17,108 @@ type Pick struct {
 	Tags   rank.Tags
 	Score  float64
 	Reason string
+}
+
+// Plan is the explainable result of an autopilot decision. Rejected contains
+// calm aggregate reasons rather than a wall of every discarded release.
+type Plan struct {
+	Picks      []Pick
+	Rejected   map[string]int
+	TotalBytes int64
+	Queued     int
+	Outcome    string
+}
+
+// BuildPlan applies safety constraints before the normal deterministic
+// selector, then accounts for everything it did not choose.
+func BuildPlan(results []provider.Result, in Intent, w rank.Weights, known map[metainfo.Hash]bool) Plan {
+	plan := Plan{Rejected: map[string]int{}}
+	eligible := make([]provider.Result, 0, len(results))
+	for _, r := range results {
+		switch {
+		case r.Seeders < in.MinSeeders:
+			plan.Rejected["below seeder minimum"]++
+		case in.MaxSizeBytes > 0 && r.SizeBytes <= 0:
+			plan.Rejected["size unknown"]++
+		case in.MaxSizeBytes > 0 && r.SizeBytes > in.MaxSizeBytes:
+			plan.Rejected["over size limit"]++
+		case len(in.Categories) > 0 && !categoryAllowed(r.Category, in.Categories):
+			plan.Rejected["category not allowed"]++
+		case resultKnown(r, known):
+			plan.Rejected["already queued"]++
+		default:
+			eligible = append(eligible, r)
+		}
+	}
+
+	selectionIntent := in
+	selectionIntent.MinSeeders = 0
+	plan.Picks = Select(eligible, selectionIntent, w, nil)
+	selected := map[string]bool{}
+	for _, p := range plan.Picks {
+		selected[resultIdentity(p.Result)] = true
+		plan.TotalBytes += p.Result.SizeBytes
+	}
+	for _, r := range eligible {
+		if !selected[resultIdentity(r)] {
+			plan.Rejected["lower-ranked alternative or cap"]++
+		}
+	}
+	return plan
+}
+
+func resultKnown(r provider.Result, known map[metainfo.Hash]bool) bool {
+	h, ok := infoHash(r)
+	return ok && known[h]
+}
+
+func resultIdentity(r provider.Result) string {
+	return r.Provider + "\x00" + r.Magnet + "\x00" + r.DetailURL + "\x00" + r.Title
+}
+
+// categoryAllowed matches a provider category against the allowlist by whole
+// hierarchy segments, never substrings, so "movies" admits "Movies > HD" but
+// not "XXX Movies". Comparison ignores a trailing plural so 1337x's singular
+// labels ("movie") match the documented allowlist spelling ("movies").
+func categoryAllowed(category string, allowed []string) bool {
+	segments := categorySegments(category)
+	if len(segments) == 0 {
+		return false
+	}
+	for _, want := range allowed {
+		want = normalizeCategory(want)
+		if want == "" {
+			continue
+		}
+		for _, segment := range segments {
+			if segment == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// categorySegments splits hierarchical labels such as "Movies > HD",
+// "movies/hd", or nyaa's "Anime - English-translated". A compound label with
+// no separator ("XXX Movies") stays one segment.
+func categorySegments(category string) []string {
+	category = strings.ReplaceAll(category, " - ", ">")
+	parts := strings.FieldsFunc(category, func(r rune) bool {
+		return r == '>' || r == '/' || r == ',' || r == '|'
+	})
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part = normalizeCategory(part); part != "" {
+			segments = append(segments, part)
+		}
+	}
+	return segments
+}
+
+func normalizeCategory(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.TrimSuffix(s, "s")
 }
 
 // Select turns raw search results into a deduplicated set of best-choice

--- a/internal/autopilot/select_test.go
+++ b/internal/autopilot/select_test.go
@@ -121,3 +121,56 @@ func TestSelectSeederFloorAndCap(t *testing.T) {
 		t.Error("Movie A is below the seeder floor and must be excluded")
 	}
 }
+
+func TestBuildPlanExplainsSafetyRejections(t *testing.T) {
+	knownMagnet := hashMagnet("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+	knownMeta, _ := metainfo.ParseMagnetUri(knownMagnet)
+	results := []provider.Result{
+		{Title: "Good Movie 1080p", Provider: "test", Category: "Movies/HD", Seeders: 50, SizeBytes: 2 << 30, Magnet: hashMagnet("1111111111111111111111111111111111111111")},
+		{Title: "Huge Movie 1080p", Provider: "test", Category: "Movies/HD", Seeders: 50, SizeBytes: 20 << 30, Magnet: hashMagnet("2222222222222222222222222222222222222222")},
+		{Title: "Mystery Movie 1080p", Provider: "test", Category: "Movies/HD", Seeders: 50, Magnet: hashMagnet("3333333333333333333333333333333333333333")},
+		{Title: "Quiet Movie 1080p", Provider: "test", Category: "Movies/HD", Seeders: 2, SizeBytes: 1 << 30, Magnet: hashMagnet("4444444444444444444444444444444444444444")},
+		{Title: "Wrong Category 1080p", Provider: "test", Category: "Anime", Seeders: 50, SizeBytes: 1 << 30, Magnet: hashMagnet("5555555555555555555555555555555555555555")},
+		{Title: "Known Movie 1080p", Provider: "test", Category: "Movies", Seeders: 50, SizeBytes: 1 << 30, Magnet: knownMagnet},
+	}
+	in := Intent{Query: "movie", MinSeeders: 5, Max: 10, MaxSizeBytes: 8 << 30, Categories: []string{"movies"}}
+	plan := BuildPlan(results, in, rank.DefaultWeights(), map[metainfo.Hash]bool{knownMeta.InfoHash: true})
+	if len(plan.Picks) != 1 || plan.Picks[0].Result.Title != "Good Movie 1080p" {
+		t.Fatalf("picks = %v, want only Good Movie", titles(plan.Picks))
+	}
+	for reason, want := range map[string]int{
+		"over size limit": 1, "size unknown": 1, "below seeder minimum": 1,
+		"category not allowed": 1, "already queued": 1,
+	} {
+		if got := plan.Rejected[reason]; got != want {
+			t.Errorf("rejected[%q] = %d, want %d", reason, got, want)
+		}
+	}
+	if plan.TotalBytes != 2<<30 {
+		t.Fatalf("TotalBytes = %d, want %d", plan.TotalBytes, int64(2<<30))
+	}
+}
+
+func TestCategoryAllowedMatchesSegmentsNotSubstrings(t *testing.T) {
+	cases := []struct {
+		category string
+		allowed  []string
+		want     bool
+	}{
+		{"Movies", []string{"movies"}, true},
+		{"movie", []string{"movies"}, true}, // 1337x singular icon label
+		{"Movies > HD", []string{"movies"}, true},
+		{"movies/hd", []string{"movies"}, true},
+		{"Anime - English-translated", []string{"anime"}, true},
+		{"XXX Movies", []string{"movies"}, false},
+		{"XXX", []string{"movies", "anime"}, false},
+		{"Anime Music Video", []string{"anime"}, false},
+		{"", []string{"movies"}, false},
+		{"Movies", nil, false},
+	}
+	for _, tc := range cases {
+		if got := categoryAllowed(tc.category, tc.allowed); got != tc.want {
+			t.Errorf("categoryAllowed(%q, %v) = %v, want %v", tc.category, tc.allowed, got, tc.want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,10 @@ func (p ProviderConfig) BaseURLs() []string {
 }
 
 type AutopilotConfig struct {
-	MaxDownloads int `yaml:"max_downloads"`
-	MinSeeders   int `yaml:"min_seeders"`
+	MaxDownloads      int      `yaml:"max_downloads"`
+	MinSeeders        int      `yaml:"min_seeders"`
+	MaxSizeGB         float64  `yaml:"max_size_gb,omitempty"`
+	AllowedCategories []string `yaml:"allowed_categories,omitempty"`
 }
 
 // HealthConfig tunes the opportunistic health check that runs on launch when
@@ -51,6 +53,12 @@ type HealthConfig struct {
 // is deliberately global: searches and downloads share the same privacy path.
 type ProxyConfig struct {
 	SOCKS5 string `yaml:"socks5,omitempty"`
+}
+
+type MetadataCacheConfig struct {
+	Enabled    bool `yaml:"enabled"`
+	MaxMB      int  `yaml:"max_mb"`
+	MaxEntries int  `yaml:"max_entries"`
 }
 
 // Interval is the gap between automatic health checks. A missing or nonsensical
@@ -75,6 +83,7 @@ type Config struct {
 	Autopilot             AutopilotConfig           `yaml:"autopilot"`
 	Health                HealthConfig              `yaml:"health"`
 	Proxy                 ProxyConfig               `yaml:"proxy"`
+	MetadataCache         MetadataCacheConfig       `yaml:"metadata_cache"`
 	Providers             map[string]ProviderConfig `yaml:"providers"`
 
 	dir          string // ~/.tork, resolved at load time
@@ -103,6 +112,8 @@ func (c *Config) Dir() string                  { return c.dir }
 func (c *Config) StatePath() string            { return filepath.Join(c.dir, "state.json") }
 func (c *Config) ConfigPath() string           { return filepath.Join(c.dir, "config.yaml") }
 func (c *Config) HealthPath() string           { return filepath.Join(c.dir, "health.json") }
+func (c *Config) AutopilotHistoryPath() string { return filepath.Join(c.dir, "autopilot.jsonl") }
+func (c *Config) MetadataCacheDir() string     { return filepath.Join(c.dir, "metainfo") }
 func (c *Config) PieceCompletionDir() string   { return c.dir }
 func (c *Config) ProxyRuntime() *proxy.Runtime { return c.proxyRuntime }
 
@@ -181,6 +192,7 @@ func Default(dir string) *Config {
 		Ranking:               rank.DefaultWeights(),
 		Autopilot:             AutopilotConfig{MaxDownloads: 10, MinSeeders: 5},
 		Health:                HealthConfig{Enabled: false, IntervalHours: 24},
+		MetadataCache:         MetadataCacheConfig{Enabled: true, MaxMB: 256, MaxEntries: 512},
 		Providers: map[string]ProviderConfig{
 			"knaben": {Enabled: true, Type: "knaben", Mirror: "https://knaben.org"},
 			"yts":    {Enabled: true, Type: "yts", Mirror: "https://yts.mx"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,9 @@ func TestLoadFromWritesDefaultsOnFirstRun(t *testing.T) {
 	if cfg.Health.Enabled || cfg.Health.IntervalHours != 24 {
 		t.Errorf("health defaults = %+v, want disabled daily checks", cfg.Health)
 	}
+	if !cfg.MetadataCache.Enabled || cfg.MetadataCache.MaxMB != 256 || cfg.MetadataCache.MaxEntries != 512 {
+		t.Errorf("metadata cache defaults = %+v", cfg.MetadataCache)
+	}
 }
 
 func TestLoadReadOnlyDoesNotCreateFiles(t *testing.T) {
@@ -115,6 +118,48 @@ func TestLoadFromReadsExistingFile(t *testing.T) {
 	}
 	if cfg.Providers["eztv"].Enabled {
 		t.Error("eztv should remain opt-in after merge")
+	}
+}
+
+func TestLoadFromReadsAutopilotSafetyDefaults(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".tork")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "autopilot:\n  max_downloads: 3\n  min_seeders: 12\n  max_size_gb: 8.5\n  allowed_categories: [movies, anime]\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Autopilot.MaxDownloads != 3 || cfg.Autopilot.MinSeeders != 12 || cfg.Autopilot.MaxSizeGB != 8.5 {
+		t.Fatalf("autopilot config = %+v", cfg.Autopilot)
+	}
+	if len(cfg.Autopilot.AllowedCategories) != 2 || cfg.Autopilot.AllowedCategories[1] != "anime" {
+		t.Fatalf("autopilot categories = %v", cfg.Autopilot.AllowedCategories)
+	}
+}
+
+func TestLoadFromReadsMetadataCacheSettings(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".tork")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "metadata_cache:\n  enabled: false\n  max_mb: 32\n  max_entries: 40\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MetadataCache.Enabled || cfg.MetadataCache.MaxMB != 32 || cfg.MetadataCache.MaxEntries != 40 {
+		t.Fatalf("metadata cache config = %+v", cfg.MetadataCache)
+	}
+	if _, err := os.Stat(cfg.MetadataCacheDir()); !os.IsNotExist(err) {
+		t.Fatalf("config load eagerly created cache directory: %v", err)
 	}
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -22,6 +23,8 @@ import (
 	"github.com/anacrolix/torrent/storage"
 
 	"github.com/melqtx/tork/internal/config"
+	"github.com/melqtx/tork/internal/intake"
+	"github.com/melqtx/tork/internal/metacache"
 )
 
 type TorrentState int
@@ -79,6 +82,67 @@ type Snapshot struct {
 	Seeders        int // peers we are connected to that hold the complete torrent
 	State          TorrentState
 	Note           string // short human status (direct downloads: failure reason)
+	Metadata       MetadataStatus
+}
+
+type MetadataSource string
+
+const (
+	MetadataPeers MetadataSource = "peers"
+	MetadataCache MetadataSource = "cache"
+	MetadataFile  MetadataSource = "file"
+	MetadataURL   MetadataSource = "url"
+)
+
+type MetadataStatus struct {
+	Source      MetadataSource
+	Waiting     time.Duration
+	PeersActive int
+	PeersTotal  int
+	Trackers    int
+	DHTEnabled  bool
+	ProxyStrict bool
+}
+
+func (m MetadataStatus) Summary() string {
+	var parts []string
+	if m.PeersTotal > 0 {
+		parts = append(parts, fmt.Sprintf("%d peers seen", m.PeersTotal))
+	}
+	if m.Trackers > 0 {
+		label := "trackers"
+		if m.Trackers == 1 {
+			label = "tracker"
+		}
+		if m.ProxyStrict {
+			label = "TCP " + label
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", m.Trackers, label))
+	}
+	if m.DHTEnabled {
+		parts = append(parts, "DHT")
+	} else if m.ProxyStrict {
+		parts = append(parts, "DHT off")
+	}
+	if m.Waiting > 0 {
+		parts = append(parts, m.Waiting.Round(time.Second).String())
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (m MetadataStatus) SourceLabel() string {
+	switch m.Source {
+	case MetadataCache:
+		return "cached metadata"
+	case MetadataFile:
+		return "local torrent"
+	case MetadataURL:
+		return "remote torrent"
+	case MetadataPeers:
+		return "peer metadata"
+	default:
+		return ""
+	}
 }
 
 func (s Snapshot) Progress() float64 {
@@ -96,20 +160,23 @@ type AddOptions struct {
 }
 
 type item struct {
-	t             *torrent.Torrent // nil while paused
-	magnet        string
-	name          string // last known name, survives pause
-	downloadDir   string
-	dataPath      string
-	length        int64 // last known length
-	done          int64 // last known completed bytes
-	paused        bool
-	preview       bool // fetched metadata only; awaiting StartDownload
-	seeding       bool
-	noSeedApplied bool  // connections already capped for a completed non-seeding item
-	excluded      []int // file indices not to download
-	selectedBytes int64 // sum of non-excluded file lengths (0 until applied)
-	samples       ring
+	t              *torrent.Torrent // nil while paused
+	magnet         string
+	name           string // last known name, survives pause
+	downloadDir    string
+	dataPath       string
+	length         int64 // last known length
+	done           int64 // last known completed bytes
+	paused         bool
+	preview        bool // fetched metadata only; awaiting StartDownload
+	seeding        bool
+	noSeedApplied  bool  // connections already capped for a completed non-seeding item
+	excluded       []int // file indices not to download
+	selectedBytes  int64 // sum of non-excluded file lengths (0 until applied)
+	metadataSource MetadataSource
+	metadataStart  time.Time
+	trackerCount   int
+	samples        ring
 }
 
 type Engine struct {
@@ -120,11 +187,13 @@ type Engine struct {
 	items   map[metainfo.Hash]*item
 	direct  map[metainfo.Hash]*directItem // plain-HTTPS downloads (see direct.go)
 	dwg     sync.WaitGroup                // running direct-download goroutines
+	mwg     sync.WaitGroup                // metadata-ready/cache goroutines
 	pcClose func()                        // bolt piece-completion closer
 
 	torrentHTTP *http.Client
 	directHTTP  *http.Client
 	strictProxy bool
+	metainfo    *metacache.Cache
 }
 
 func New(cfg *config.Config) (*Engine, error) {
@@ -202,6 +271,7 @@ func New(cfg *config.Config) (*Engine, error) {
 		torrentHTTP: torrentHTTP,
 		directHTTP:  directHTTP,
 		strictProxy: strictProxy,
+		metainfo:    metacache.New(cfg),
 	}, nil
 }
 
@@ -252,9 +322,31 @@ func (e *Engine) addMagnetWithOptions(magnet string, opts AddOptions) (metainfo.
 		}
 		e.mu.Unlock()
 	}
+	magnetSpec := spec
+	metadataSource := MetadataPeers
+	cacheHit := false
+	if !spec.InfoHash.IsZero() {
+		if cached, ok := e.metainfo.Load(metainfo.Hash(spec.InfoHash)); ok {
+			if cachedSpec, cacheErr := torrent.TorrentSpecFromMetaInfoErr(cached); cacheErr == nil {
+				mergeSpecHints(cachedSpec, spec)
+				spec = cachedSpec
+				metadataSource = MetadataCache
+				cacheHit = true
+			} else {
+				e.metainfo.Discard(metainfo.Hash(spec.InfoHash))
+			}
+		}
+	}
 	e.prepareSpec(spec, opts.DownloadDir)
 
 	t, _, err := e.client.AddTorrentSpec(spec)
+	if err != nil && cacheHit {
+		e.metainfo.Discard(metainfo.Hash(magnetSpec.InfoHash))
+		spec = magnetSpec
+		metadataSource = MetadataPeers
+		e.prepareSpec(spec, opts.DownloadDir)
+		t, _, err = e.client.AddTorrentSpec(spec)
+	}
 	if err != nil {
 		return metainfo.Hash{}, false, err
 	}
@@ -269,18 +361,24 @@ func (e *Engine) addMagnetWithOptions(magnet string, opts AddOptions) (metainfo.
 			existing.downloadDir = opts.DownloadDir
 			existing.seeding = *opts.Seed
 			existing.noSeedApplied = false
+			existing.metadataSource = metadataSource
+			existing.metadataStart = time.Now()
+			existing.trackerCount = trackerCount(spec.Trackers)
 			e.startWhenReady(t, h)
 		}
 		e.mu.Unlock()
 		return h, false, nil
 	}
 	e.items[h] = &item{
-		t:           t,
-		magnet:      magnet,
-		downloadDir: opts.DownloadDir,
-		seeding:     *opts.Seed,
-		excluded:    opts.Excluded,
-		preview:     opts.Preview,
+		t:              t,
+		magnet:         magnet,
+		downloadDir:    opts.DownloadDir,
+		seeding:        *opts.Seed,
+		excluded:       opts.Excluded,
+		preview:        opts.Preview,
+		metadataSource: metadataSource,
+		metadataStart:  time.Now(),
+		trackerCount:   trackerCount(spec.Trackers),
 	}
 	e.mu.Unlock()
 
@@ -291,10 +389,6 @@ func (e *Engine) addMagnetWithOptions(magnet string, opts AddOptions) (metainfo.
 // torrentClient fetches .torrent files; a plain timeout is enough since these
 // are small and served by official mirrors.
 var torrentClient = &http.Client{Timeout: 30 * time.Second}
-
-// maxTorrentBytes caps a fetched .torrent file. Even a large multi-GiB image
-// has a metainfo of a few MiB at most.
-const maxTorrentBytes = 16 << 20
 
 // AddTorrentURL fetches an official .torrent file over HTTP and starts
 // downloading it, exactly like Add does for a magnet. It derives a magnet URI
@@ -315,6 +409,7 @@ func (e *Engine) AddTorrentURLWithOptions(ctx context.Context, url string, opts 
 	if err != nil {
 		return metainfo.Hash{}, "", "", fmt.Errorf("read torrent: %w", err)
 	}
+	_ = e.metainfo.Store(*mi)
 
 	spec := torrent.TorrentSpecFromMetaInfo(mi)
 	e.prepareSpec(spec, opts.DownloadDir)
@@ -335,6 +430,9 @@ func (e *Engine) AddTorrentURLWithOptions(ctx context.Context, url string, opts 
 			existing.downloadDir = opts.DownloadDir
 			existing.seeding = *opts.Seed
 			existing.noSeedApplied = false
+			existing.metadataSource = MetadataURL
+			existing.metadataStart = time.Now()
+			existing.trackerCount = trackerCount(spec.Trackers)
 			e.startWhenReady(t, h)
 		}
 		magnet = existing.magnet
@@ -342,13 +440,16 @@ func (e *Engine) AddTorrentURLWithOptions(ctx context.Context, url string, opts 
 		return h, name, magnet, nil
 	}
 	e.items[h] = &item{
-		t:           t,
-		magnet:      magnet,
-		name:        name,
-		downloadDir: opts.DownloadDir,
-		seeding:     *opts.Seed,
-		excluded:    opts.Excluded,
-		preview:     opts.Preview,
+		t:              t,
+		magnet:         magnet,
+		name:           name,
+		downloadDir:    opts.DownloadDir,
+		seeding:        *opts.Seed,
+		excluded:       opts.Excluded,
+		preview:        opts.Preview,
+		metadataSource: MetadataURL,
+		metadataStart:  time.Now(),
+		trackerCount:   trackerCount(spec.Trackers),
 	}
 	e.mu.Unlock()
 
@@ -360,16 +461,38 @@ func (e *Engine) AddTorrentURLWithOptions(ctx context.Context, url string, opts 
 // mode. It returns owned=false when the torrent was already tracked, so callers
 // know cancel must not remove it.
 func (e *Engine) AddTorrentURLForPreview(ctx context.Context, url string) (h metainfo.Hash, name, magnet string, owned bool, err error) {
-	return e.addTorrentURLForPreviewWithOptions(ctx, url, AddOptions{Preview: true})
-}
-
-func (e *Engine) addTorrentURLForPreviewWithOptions(ctx context.Context, url string, opts AddOptions) (h metainfo.Hash, name, magnet string, owned bool, err error) {
-	opts.Preview = true
-	opts = e.normalizeOptions(opts)
 	mi, err := e.fetchMetaInfo(ctx, url)
 	if err != nil {
 		return metainfo.Hash{}, "", "", false, fmt.Errorf("fetch torrent: %w", err)
 	}
+	return e.addMetaInfoForPreview(mi, AddOptions{Preview: true}, MetadataURL)
+}
+
+// AddTorrentFileForPreview reads a bounded local metainfo file and opens it in
+// the same preview flow as a remote .torrent URL.
+func (e *Engine) AddTorrentFileForPreview(path string) (h metainfo.Hash, name, magnet string, owned bool, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return metainfo.Hash{}, "", "", false, fmt.Errorf("open torrent: %w", err)
+	}
+	defer f.Close()
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return metainfo.Hash{}, "", "", false, err
+	}
+	if !fileInfo.Mode().IsRegular() || fileInfo.Size() <= 0 || fileInfo.Size() > intake.MaxTorrentBytes {
+		return metainfo.Hash{}, "", "", false, fmt.Errorf("torrent file must be a regular file no larger than 16 MiB")
+	}
+	mi, err := metainfo.Load(io.LimitReader(f, intake.MaxTorrentBytes+1))
+	if err != nil {
+		return metainfo.Hash{}, "", "", false, fmt.Errorf("read torrent: %w", err)
+	}
+	return e.addMetaInfoForPreview(mi, AddOptions{Preview: true}, MetadataFile)
+}
+
+func (e *Engine) addMetaInfoForPreview(mi *metainfo.MetaInfo, opts AddOptions, source MetadataSource) (h metainfo.Hash, name, magnet string, owned bool, err error) {
+	opts.Preview = true
+	opts = e.normalizeOptions(opts)
 	info, err := mi.UnmarshalInfo()
 	if err != nil {
 		return metainfo.Hash{}, "", "", false, fmt.Errorf("read torrent: %w", err)
@@ -377,6 +500,7 @@ func (e *Engine) addTorrentURLForPreviewWithOptions(ctx context.Context, url str
 	h = mi.HashInfoBytes()
 	name = info.Name
 	magnet = mi.Magnet(&h, &info).String()
+	_ = e.metainfo.Store(*mi)
 
 	e.mu.Lock()
 	if existing, ok := e.items[h]; ok {
@@ -398,13 +522,16 @@ func (e *Engine) addTorrentURLForPreviewWithOptions(ctx context.Context, url str
 
 	e.mu.Lock()
 	e.items[h] = &item{
-		t:           t,
-		magnet:      magnet,
-		name:        name,
-		downloadDir: opts.DownloadDir,
-		seeding:     *opts.Seed,
-		excluded:    opts.Excluded,
-		preview:     true,
+		t:              t,
+		magnet:         magnet,
+		name:           name,
+		downloadDir:    opts.DownloadDir,
+		seeding:        *opts.Seed,
+		excluded:       opts.Excluded,
+		preview:        true,
+		metadataSource: source,
+		metadataStart:  time.Now(),
+		trackerCount:   trackerCount(spec.Trackers),
 	}
 	e.mu.Unlock()
 
@@ -425,7 +552,19 @@ func (e *Engine) fetchMetaInfo(ctx context.Context, url string) (*metainfo.MetaI
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: unexpected status %d", url, resp.StatusCode)
 	}
-	return metainfo.Load(io.LimitReader(resp.Body, maxTorrentBytes))
+	if resp.ContentLength > intake.MaxTorrentBytes {
+		return nil, fmt.Errorf("torrent file is too large (maximum 16 MiB)")
+	}
+	// Chunked responses report no Content-Length, so the size check must also
+	// run on the bytes actually received.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, intake.MaxTorrentBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > intake.MaxTorrentBytes {
+		return nil, fmt.Errorf("torrent file is too large (maximum 16 MiB)")
+	}
+	return metainfo.Load(bytes.NewReader(data))
 }
 
 // prepareSpec applies storage and strips the transports strict SOCKS5 mode
@@ -477,23 +616,88 @@ func (e *Engine) AddForPreview(magnet string) (metainfo.Hash, bool, error) {
 }
 
 func (e *Engine) startWhenReady(t *torrent.Torrent, h metainfo.Hash) {
+	e.mwg.Add(1)
 	go func() {
+		defer e.mwg.Done()
 		defer func() { _ = recover() }() // a torrent callback must never crash the app
 		select {
 		case <-t.GotInfo():
 		case <-t.Closed():
 			return
 		}
+		mi := t.Metainfo()
+		_ = e.metainfo.Store(mi)
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		it, ok := e.items[h]
-		if !ok || it.preview {
-			return // dropped, or waiting on StartDownload
+		if !ok {
+			return // dropped
+		}
+		// Metadata can carry a fuller announce-list than the magnet did; keep
+		// the discovery feedback line honest.
+		if n := trackerCount(mi.UpvertedAnnounceList()); n > it.trackerCount {
+			it.trackerCount = n
+		}
+		if it.preview {
+			return // waiting on StartDownload
 		}
 		it.name = displayName(it)
 		it.dataPath = torrentDataPath(it)
 		e.applyExclusions(t, it, it.excluded)
 	}()
+}
+
+func mergeSpecHints(dst, src *torrent.TorrentSpec) {
+	dst.Trackers = mergeTrackerTiers(dst.Trackers, src.Trackers)
+	dst.Webseeds = appendUnique(dst.Webseeds, src.Webseeds...)
+	dst.DhtNodes = appendUnique(dst.DhtNodes, src.DhtNodes...)
+	dst.PeerAddrs = appendUnique(dst.PeerAddrs, src.PeerAddrs...)
+	dst.Sources = appendUnique(dst.Sources, src.Sources...)
+	if dst.DisplayName == "" {
+		dst.DisplayName = src.DisplayName
+	}
+}
+
+func mergeTrackerTiers(a, b [][]string) [][]string {
+	seen := map[string]bool{}
+	out := make([][]string, 0, len(a)+len(b))
+	for _, tiers := range [][][]string{a, b} {
+		for _, tier := range tiers {
+			var merged []string
+			for _, raw := range tier {
+				if raw != "" && !seen[raw] {
+					seen[raw] = true
+					merged = append(merged, raw)
+				}
+			}
+			if len(merged) > 0 {
+				out = append(out, merged)
+			}
+		}
+	}
+	return out
+}
+
+func appendUnique(dst []string, values ...string) []string {
+	seen := make(map[string]bool, len(dst)+len(values))
+	for _, value := range dst {
+		seen[value] = true
+	}
+	for _, value := range values {
+		if value != "" && !seen[value] {
+			seen[value] = true
+			dst = append(dst, value)
+		}
+	}
+	return dst
+}
+
+func trackerCount(tiers [][]string) int {
+	total := 0
+	for _, tier := range tiers {
+		total += len(tier)
+	}
+	return total
 }
 
 // applyExclusions sets per-file priorities; an empty list downloads
@@ -549,7 +753,12 @@ func (e *Engine) StartDownload(h metainfo.Hash, excluded []int) {
 	it.excluded = excluded
 	it.name = displayName(it)
 	it.dataPath = torrentDataPath(it)
-	e.applyExclusions(it.t, it, excluded)
+	// A bare infohash may be approved before any peer has supplied metadata.
+	// anacrolix's file selection methods require Info to exist, so leave the
+	// already-running startWhenReady callback to apply the selection later.
+	if it.t.Info() != nil {
+		e.applyExclusions(it.t, it, excluded)
+	}
 }
 
 // Pause drops the torrent from the client but keeps its entry; piece
@@ -741,6 +950,24 @@ func (e *Engine) Snapshot(h metainfo.Hash) (Snapshot, bool) {
 	return Snapshot{}, false
 }
 
+func (e *Engine) MetadataDiscovery(h metainfo.Hash) (MetadataStatus, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	it, ok := e.items[h]
+	if !ok || it.t == nil {
+		return MetadataStatus{}, false
+	}
+	stats := it.t.Stats()
+	status := MetadataStatus{
+		Source: it.metadataSource, PeersActive: stats.ActivePeers, PeersTotal: stats.TotalPeers,
+		Trackers: it.trackerCount, DHTEnabled: !e.strictProxy, ProxyStrict: e.strictProxy,
+	}
+	if it.t.Info() == nil && !it.metadataStart.IsZero() {
+		status.Waiting = time.Since(it.metadataStart)
+	}
+	return status, true
+}
+
 func (e *Engine) snapshot(h metainfo.Hash, it *item, now time.Time) Snapshot {
 	name := displayName(it)
 	if name != "?" {
@@ -749,7 +976,14 @@ func (e *Engine) snapshot(h metainfo.Hash, it *item, now time.Time) Snapshot {
 			it.dataPath = torrentDataPath(it)
 		}
 	}
-	s := Snapshot{Hash: h, Magnet: it.magnet, Name: name, DownloadDir: it.downloadDir, DataPath: it.dataPath, Seed: it.seeding}
+	s := Snapshot{
+		Hash: h, Magnet: it.magnet, Name: name, DownloadDir: it.downloadDir,
+		DataPath: it.dataPath, Seed: it.seeding,
+		Metadata: MetadataStatus{
+			Source: it.metadataSource, Trackers: it.trackerCount,
+			DHTEnabled: !e.strictProxy, ProxyStrict: e.strictProxy,
+		},
+	}
 
 	if it.paused || it.t == nil {
 		s.State = StatePaused
@@ -765,6 +999,11 @@ func (e *Engine) snapshot(h metainfo.Hash, it *item, now time.Time) Snapshot {
 	s.PeersActive = stats.ActivePeers
 	s.PeersTotal = stats.TotalPeers
 	s.Seeders = stats.ConnectedSeeders
+	s.Metadata.PeersActive = stats.ActivePeers
+	s.Metadata.PeersTotal = stats.TotalPeers
+	if t.Info() == nil && !it.metadataStart.IsZero() {
+		s.Metadata.Waiting = now.Sub(it.metadataStart)
+	}
 
 	it.samples.push(sample{at: now, bytes: s.BytesCompleted})
 	s.SpeedBps = it.samples.speedBps()
@@ -772,6 +1011,7 @@ func (e *Engine) snapshot(h metainfo.Hash, it *item, now time.Time) Snapshot {
 	switch {
 	case t.Info() == nil:
 		s.State = StateFetchingMeta
+		s.Note = s.Metadata.Summary()
 	case it.preview:
 		s.State = StatePreviewing
 	case s.Length > 0 && s.BytesCompleted >= s.Length:
@@ -818,6 +1058,7 @@ func (e *Engine) Close() {
 
 	e.client.Close()
 	<-e.client.Closed()
+	e.mwg.Wait()
 	e.pcClose()
 }
 

--- a/internal/engine/engine_integration_test.go
+++ b/internal/engine/engine_integration_test.go
@@ -60,8 +60,13 @@ func TestEngineDownloadsFromLocalSeeder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer seeder.Close()
-	seederT, err := seeder.AddTorrent(&mi)
+	seederClosed := false
+	defer func() {
+		if !seederClosed {
+			seeder.Close()
+		}
+	}()
+	_, err = seeder.AddTorrent(&mi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,11 +113,10 @@ func TestEngineDownloadsFromLocalSeeder(t *testing.T) {
 	}
 	eng.Close() // releases the bolt piece-completion lock
 
-	// --- resume: a fresh engine on the same dir must complete from disk.
-	// Metadata still comes from the seeder, but bolt piece completion means
-	// no payload is re-transferred - assert via the seeder's upload counter.
-	statsBefore := seederT.Stats()
-	uploadedBefore := statsBefore.BytesWrittenData.Int64()
+	// --- offline resume: cached metainfo plus bolt piece completion must make a
+	// fresh engine complete from disk after the only seeder is gone.
+	seeder.Close()
+	seederClosed = true
 
 	eng2, err := New(cfg)
 	if err != nil {
@@ -123,23 +127,17 @@ func TestEngineDownloadsFromLocalSeeder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if snap, ok := eng2.Snapshot(h2); !ok || snap.Metadata.Source != MetadataCache {
+		t.Fatalf("resume metadata = %+v, ok=%v; want cache", snap.Metadata, ok)
+	}
 	snap = awaitComplete(t, eng2, h2, 90*time.Second)
 	if snap.BytesCompleted != int64(len(payload)) {
 		t.Fatalf("resume completed %d bytes, want %d", snap.BytesCompleted, len(payload))
 	}
-	statsAfter := seederT.Stats()
-	uploadedDuringResume := statsAfter.BytesWrittenData.Int64() - uploadedBefore
-	if uploadedDuringResume > 64<<10 {
-		t.Errorf("resume re-downloaded %d bytes from seeder; piece completion should have prevented that", uploadedDuringResume)
-	}
 }
 
 func TestAddWithOptionsRecordsDownloadDir(t *testing.T) {
-	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
-	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	cfg := strictProxyConfig(t, "127.0.0.1:1")
 	eng, err := New(cfg)
 	if err != nil {
 		t.Fatal(err)
@@ -158,6 +156,156 @@ func TestAddWithOptionsRecordsDownloadDir(t *testing.T) {
 	}
 	if snap.DownloadDir != dir {
 		t.Fatalf("DownloadDir = %q, want %q", snap.DownloadDir, dir)
+	}
+}
+
+func TestLocalTorrentFilePreviewCachesForOfflineReopen(t *testing.T) {
+	seedDir := t.TempDir()
+	payloadPath := filepath.Join(seedDir, "local.bin")
+	if err := os.WriteFile(payloadPath, []byte("local torrent payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := metainfo.Info{PieceLength: 16 << 10}
+	if err := info.BuildFromFilePath(payloadPath); err != nil {
+		t.Fatal(err)
+	}
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mi := metainfo.MetaInfo{InfoBytes: infoBytes, Announce: "https://tracker.example/announce"}
+	torrentPath := filepath.Join(t.TempDir(), "local.torrent")
+	f, err := os.Create(torrentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mi.Write(f); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := strictProxyConfig(t, "127.0.0.1:1")
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, name, magnet, owned, err := eng.AddTorrentFileForPreview(torrentPath)
+	if err != nil {
+		eng.Close()
+		t.Fatal(err)
+	}
+	if !owned || name != "local.bin" {
+		eng.Close()
+		t.Fatalf("preview = hash %s name %q owned %v", h.HexString(), name, owned)
+	}
+	files, ready := eng.Files(h)
+	if !ready || len(files) != 1 || files[0].Path != "local.bin" {
+		eng.Close()
+		t.Fatalf("files = %+v, ready=%v", files, ready)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.Metadata.Source != MetadataFile {
+		eng.Close()
+		t.Fatalf("local metadata = %+v, ok=%v", snap.Metadata, ok)
+	}
+	eng.Close()
+	if err := os.Remove(torrentPath); err != nil {
+		t.Fatal(err)
+	}
+
+	eng2, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng2.Close()
+	h2, owned, err := eng2.AddForPreview(magnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !owned || h2 != h {
+		t.Fatalf("cached preview = hash %s owned %v", h2.HexString(), owned)
+	}
+	if files, ready := eng2.Files(h2); !ready || len(files) != 1 {
+		t.Fatalf("cached files = %+v, ready=%v", files, ready)
+	}
+	if snap, ok := eng2.Snapshot(h2); !ok || snap.Metadata.Source != MetadataCache {
+		t.Fatalf("cached metadata = %+v, ok=%v", snap.Metadata, ok)
+	}
+}
+
+func TestInvalidSemanticCacheFallsBackToMagnet(t *testing.T) {
+	cfg := strictProxyConfig(t, "127.0.0.1:1")
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	// Decodes as an info dictionary, but has no piece hash for its one piece;
+	// the torrent client rejects it even though the cache's lightweight parser
+	// can read it.
+	infoBytes, err := bencode.Marshal(metainfo.Info{Name: "bad.bin", PieceLength: 16 << 10, Length: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mi := metainfo.MetaInfo{InfoBytes: infoBytes}
+	if err := eng.metainfo.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	hash := mi.HashInfoBytes()
+	h, _, err := eng.AddForPreview("magnet:?xt=urn:btih:" + hash.HexString())
+	if err != nil {
+		t.Fatalf("fallback magnet add failed: %v", err)
+	}
+	status, ok := eng.MetadataDiscovery(h)
+	if !ok || status.Source != MetadataPeers {
+		t.Fatalf("fallback discovery = %+v, ok=%v", status, ok)
+	}
+	cachePath := filepath.Join(cfg.MetadataCacheDir(), hash.HexString()+".torrent")
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Fatalf("rejected cache entry was not discarded: %v", err)
+	}
+}
+
+func TestDisabledMetadataCacheDoesNotPersistLocalTorrent(t *testing.T) {
+	payloadPath := filepath.Join(t.TempDir(), "disabled.bin")
+	if err := os.WriteFile(payloadPath, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := metainfo.Info{PieceLength: 16 << 10}
+	if err := info.BuildFromFilePath(payloadPath); err != nil {
+		t.Fatal(err)
+	}
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mi := metainfo.MetaInfo{InfoBytes: infoBytes}
+	torrentPath := filepath.Join(t.TempDir(), "disabled.torrent")
+	f, err := os.Create(torrentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mi.Write(f); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	cfg := strictProxyConfig(t, "127.0.0.1:1")
+	cfg.MetadataCache.Enabled = false
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, err := eng.AddTorrentFileForPreview(torrentPath); err != nil {
+		eng.Close()
+		t.Fatal(err)
+	}
+	eng.Close()
+	if _, err := os.Stat(cfg.MetadataCacheDir()); !os.IsNotExist(err) {
+		t.Fatalf("disabled cache created directory: %v", err)
 	}
 }
 
@@ -217,6 +365,9 @@ func TestPreviewAndExcludeFiles(t *testing.T) {
 			break
 		}
 	}
+	if port == 0 {
+		t.Fatal("seeder has no TCP listen addr")
+	}
 
 	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
 	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
@@ -229,30 +380,41 @@ func TestPreviewAndExcludeFiles(t *testing.T) {
 	}
 	defer eng.Close()
 
-	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%s&x.pe=127.0.0.1:%d", mi.HashInfoBytes().HexString(), port)
-	h, owned, err := eng.AddForPreview(magnet)
+	torrentPath := filepath.Join(t.TempDir(), "pack.torrent")
+	f, err := os.Create(torrentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mi.Write(f); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	h, _, _, owned, err := eng.AddTorrentFileForPreview(torrentPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !owned {
-		t.Fatal("first preview add should own the metadata-only torrent")
+		t.Fatal("first local preview should own the torrent")
 	}
-
-	// wait for metadata; nothing should download while previewing
-	var files []FileInfo
-	deadline := time.After(90 * time.Second)
-	for files == nil {
-		select {
-		case <-deadline:
-			t.Fatal("metadata never arrived for preview")
-		case <-time.After(100 * time.Millisecond):
-		}
-		if fs, ok := eng.Files(h); ok {
-			files = fs
-		}
+	eng.mu.Lock()
+	leecher := eng.items[h].t
+	eng.mu.Unlock()
+	leecher.AddPeers([]torrent.PeerInfo{{
+		Addr:   &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port},
+		Source: torrent.PeerSourceDirect,
+	}})
+	files, ready := eng.Files(h)
+	if !ready {
+		t.Fatal("local metainfo was not ready immediately")
 	}
 	if len(files) != 3 {
 		t.Fatalf("Files returned %d entries, want 3", len(files))
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.Metadata.Source != MetadataFile {
+		t.Fatalf("local preview metadata = %+v, ok=%v", snap.Metadata, ok)
 	}
 
 	// find the largest file (big.dat) and exclude it

--- a/internal/engine/metainfo_test.go
+++ b/internal/engine/metainfo_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/anacrolix/torrent"
+	"github.com/melqtx/tork/internal/intake"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestFetchMetaInfoRejectsOversizedResponse(t *testing.T) {
+	eng := &Engine{torrentHTTP: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: intake.MaxTorrentBytes + 1,
+			Body:          io.NopCloser(strings.NewReader("unused")),
+		}, nil
+	})}}
+	if _, err := eng.fetchMetaInfo(t.Context(), "https://example.test/download?id=1"); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("oversized response error = %v", err)
+	}
+}
+
+func TestFetchMetaInfoRejectsOversizedChunkedResponse(t *testing.T) {
+	// A chunked response carries no Content-Length, so the cap must apply to
+	// the bytes actually read, with the size error rather than a bencode one.
+	body := io.MultiReader(
+		strings.NewReader("d8:announce"),
+		io.LimitReader(zeroReader{}, intake.MaxTorrentBytes+1),
+	)
+	eng := &Engine{torrentHTTP: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			ContentLength: -1,
+			Body:          io.NopCloser(body),
+		}, nil
+	})}}
+	if _, err := eng.fetchMetaInfo(t.Context(), "https://example.test/big"); err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("oversized chunked response error = %v", err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func TestAddTorrentFileRejectsMalformedAndOversizedFiles(t *testing.T) {
+	eng := &Engine{}
+	bad := filepath.Join(t.TempDir(), "bad.torrent")
+	if err := os.WriteFile(bad, []byte("not metainfo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, _, err := eng.AddTorrentFileForPreview(bad); err == nil || !strings.Contains(err.Error(), "read torrent") {
+		t.Fatalf("malformed file error = %v", err)
+	}
+	large := filepath.Join(t.TempDir(), "large.torrent")
+	f, err := os.Create(large)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(intake.MaxTorrentBytes + 1); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if _, _, _, _, err := eng.AddTorrentFileForPreview(large); err == nil || !strings.Contains(err.Error(), "16 MiB") {
+		t.Fatalf("oversized file error = %v", err)
+	}
+}
+
+func TestMergeSpecHintsPreservesAndDeduplicatesDiscovery(t *testing.T) {
+	dst := &torrent.TorrentSpec{
+		Trackers: [][]string{{"https://cached/announce"}},
+		Webseeds: []string{"https://cached/file"},
+	}
+	src := &torrent.TorrentSpec{
+		Trackers:    [][]string{{"https://cached/announce", "https://magnet/announce"}},
+		Webseeds:    []string{"https://cached/file", "https://magnet/file"},
+		PeerAddrs:   []string{"127.0.0.1:6881"},
+		DisplayName: "magnet name",
+	}
+	mergeSpecHints(dst, src)
+	if trackerCount(dst.Trackers) != 2 {
+		t.Fatalf("trackers = %#v", dst.Trackers)
+	}
+	if len(dst.Webseeds) != 2 || len(dst.PeerAddrs) != 1 || dst.DisplayName != "magnet name" {
+		t.Fatalf("merged spec = %+v", dst)
+	}
+}

--- a/internal/engine/proxy_test.go
+++ b/internal/engine/proxy_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/anacrolix/torrent"
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
 
 	"github.com/melqtx/tork/internal/config"
 )
@@ -92,6 +94,38 @@ func TestStrictProxyFiltersUnsafeTorrentTransports(t *testing.T) {
 	}
 	if spec.DhtNodes != nil {
 		t.Fatalf("strict proxy DHT nodes = %#v, want nil", spec.DhtNodes)
+	}
+}
+
+func TestStrictProxySanitizesCachedDiscoveryHints(t *testing.T) {
+	eng, err := New(strictProxyConfig(t, "127.0.0.1:9050"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	infoBytes, err := bencode.Marshal(metainfo.Info{Name: "cached.bin", PieceLength: 16 << 10, Length: 1, Pieces: make([]byte, 20)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mi := metainfo.MetaInfo{
+		InfoBytes: infoBytes,
+		AnnounceList: metainfo.AnnounceList{
+			{"udp://tracker.example:6969", "https://tracker.example/announce"},
+		},
+		Nodes: []metainfo.Node{"node.example:6881"},
+	}
+	if err := eng.metainfo.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	magnet := "magnet:?xt=urn:btih:" + mi.HashInfoBytes().HexString() +
+		"&tr=http%3A%2F%2Ftracker-two.example%2Fannounce"
+	h, _, err := eng.AddForPreview(magnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, ok := eng.MetadataDiscovery(h)
+	if !ok || status.Source != MetadataCache || status.Trackers != 2 || status.DHTEnabled || !status.ProxyStrict {
+		t.Fatalf("cached strict discovery = %+v, ok=%v", status, ok)
 	}
 }
 

--- a/internal/engine/stats_test.go
+++ b/internal/engine/stats_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -23,6 +24,20 @@ func TestRingSpeed(t *testing.T) {
 	want := float64(1 << 20)
 	if got < want*0.99 || got > want*1.01 {
 		t.Errorf("speed = %f, want ~%f", got, want)
+	}
+}
+
+func TestMetadataStatusSummaryIsTruthful(t *testing.T) {
+	direct := MetadataStatus{PeersTotal: 3, Trackers: 16, DHTEnabled: true, Waiting: 12 * time.Second}
+	got := direct.Summary()
+	for _, want := range []string{"3 peers seen", "16 trackers", "DHT", "12s"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q omitted %q", got, want)
+		}
+	}
+	strict := MetadataStatus{Trackers: 1, ProxyStrict: true}
+	if got := strict.Summary(); !strings.Contains(got, "1 TCP tracker") || !strings.Contains(got, "DHT off") {
+		t.Fatalf("strict summary = %q", got)
 	}
 }
 

--- a/internal/health/doctor.go
+++ b/internal/health/doctor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/melqtx/tork/internal/config"
+	"github.com/melqtx/tork/internal/metacache"
 	"github.com/melqtx/tork/internal/provider"
 	"github.com/melqtx/tork/internal/proxy"
 	"github.com/melqtx/tork/internal/state"
@@ -107,6 +108,7 @@ func runDoctor(ctx context.Context, cfg *config.Config, providers []provider.Pro
 	}
 	rep.Checks = append(rep.Checks, checkDownloadDir(cfg))
 	rep.Checks = append(rep.Checks, checkState(cfg))
+	rep.Checks = append(rep.Checks, checkMetadataCache(cfg))
 	rep.Checks = append(rep.Checks, checkEngine(cfg, engineProbe))
 
 	if cfg.ProxyError() != nil {
@@ -294,6 +296,35 @@ func checkState(cfg *config.Config) Check {
 	}
 	c.Status = StatusOK
 	c.Detail = fmt.Sprintf("%d entries", len(st.Entries))
+	return c
+}
+
+func checkMetadataCache(cfg *config.Config) Check {
+	c := Check{Name: "metadata cache"}
+	rep := metacache.New(cfg).Inspect()
+	if !rep.Enabled {
+		c.Status = StatusOK
+		c.Detail = "disabled"
+		return c
+	}
+	if rep.Err != nil {
+		c.Status = StatusWarn
+		c.Detail = fmt.Sprintf("unreadable: %v", rep.Err)
+		return c
+	}
+	if !rep.Exists {
+		c.Status = StatusOK
+		c.Detail = "empty; created when metadata is first cached"
+		return c
+	}
+	if rep.Invalid > 0 || rep.Insecure > 0 {
+		c.Status = StatusWarn
+		c.Detail = fmt.Sprintf("%d entries · %s · %d invalid · %d insecure permissions",
+			rep.Entries, humanBytes(rep.Bytes), rep.Invalid, rep.Insecure)
+		return c
+	}
+	c.Status = StatusOK
+	c.Detail = fmt.Sprintf("%d entries · %s", rep.Entries, humanBytes(rep.Bytes))
 	return c
 }
 

--- a/internal/health/doctor_test.go
+++ b/internal/health/doctor_test.go
@@ -357,6 +357,43 @@ func TestDoctorDefaultChecksDoNotWriteDownloadOrHealthFiles(t *testing.T) {
 	}
 }
 
+func TestDoctorMetadataCacheCheckIsReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default(dir)
+	if err := os.MkdirAll(cfg.DownloadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rep := RunDoctor(context.Background(), cfg, []provider.Provider{fakeProvider{name: "p"}}, OpenReadOnly(cfg.HealthPath()), nil)
+	c := findCheck(t, rep, "metadata cache")
+	if c.Status != StatusOK || !strings.Contains(c.Detail, "first cached") {
+		t.Fatalf("metadata cache check = %+v", c)
+	}
+	if _, err := os.Stat(cfg.MetadataCacheDir()); !os.IsNotExist(err) {
+		t.Fatalf("doctor created metadata cache: %v", err)
+	}
+}
+
+func TestDoctorReportsInvalidCacheWithoutRepairing(t *testing.T) {
+	cfg := testConfig(t)
+	if err := os.MkdirAll(cfg.MetadataCacheDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfg.MetadataCacheDir(), strings.Repeat("a", 40)+".torrent")
+	bad := []byte("broken metainfo")
+	if err := os.WriteFile(path, bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rep := RunDoctor(context.Background(), cfg, []provider.Provider{fakeProvider{name: "p"}}, OpenReadOnly(cfg.HealthPath()), nil)
+	c := findCheck(t, rep, "metadata cache")
+	if c.Status != StatusWarn || !strings.Contains(c.Detail, "1 invalid") {
+		t.Fatalf("metadata cache check = %+v", c)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != string(bad) {
+		t.Fatalf("doctor repaired cache: %q, %v", got, err)
+	}
+}
+
 // An entry whose data vanished is worth flagging, but tork still runs.
 func TestDoctorMissingDataWarns(t *testing.T) {
 	cfg := testConfig(t)

--- a/internal/intake/intake.go
+++ b/internal/intake/intake.go
@@ -1,0 +1,153 @@
+// Package intake classifies user-supplied torrent inputs without performing
+// network requests. It is shared by the CLI and the TUI home field so both
+// surfaces accept the same magnets, hashes, URLs, and local files.
+package intake
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/melqtx/tork/internal/provider"
+)
+
+const MaxTorrentBytes int64 = 16 << 20
+
+type Kind int
+
+const (
+	Magnet Kind = iota
+	InfoHash
+	TorrentURL
+	TorrentFile
+)
+
+type Target struct {
+	Kind  Kind
+	Value string // original magnet/URL, or absolute local path
+	Name  string // best-effort display name
+}
+
+var (
+	reHexInfoHash    = regexp.MustCompile(`(?i)^[0-9a-f]{40}$`)
+	reBase32InfoHash = regexp.MustCompile(`(?i)^[a-z2-7]{32}$`)
+)
+
+// DetectCLI accepts every supported explicit positional input. Any existing
+// regular file is offered to the metainfo decoder even without a .torrent
+// suffix; ordinary nonexistent text is left unclassified.
+func DetectCLI(raw string) (Target, bool, error) {
+	return detect(raw, true)
+}
+
+// DetectHome is conservative around local paths so a search term that happens
+// to name a file is not hijacked. Only .torrent-looking paths that actually
+// exist are classified; anything else stays a search query.
+func DetectHome(raw string) (Target, bool, error) {
+	return detect(raw, false)
+}
+
+// ExplicitTorrentURL validates --torrent-url values without requiring their
+// path to end in .torrent.
+func ExplicitTorrentURL(raw string) (Target, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return Target{}, errors.New("--torrent-url requires an absolute http or https URL")
+	}
+	return Target{Kind: TorrentURL, Value: raw, Name: urlName(u)}, nil
+}
+
+func detect(raw string, allowAnyExistingFile bool) (Target, bool, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Target{}, false, nil
+	}
+	lower := strings.ToLower(raw)
+	if strings.HasPrefix(lower, "magnet:?") {
+		return Target{Kind: Magnet, Value: raw, Name: magnetName(raw)}, true, nil
+	}
+	if reHexInfoHash.MatchString(raw) || reBase32InfoHash.MatchString(raw) {
+		return Target{
+			Kind: InfoHash, Value: provider.BuildMagnet(raw, "", provider.DefaultTrackers),
+		}, true, nil
+	}
+	if u, ok := automaticTorrentURL(raw); ok {
+		return Target{Kind: TorrentURL, Value: raw, Name: urlName(u)}, true, nil
+	}
+
+	path, looksLikeTorrent := localPath(raw)
+	if !allowAnyExistingFile && !looksLikeTorrent {
+		return Target{}, false, nil
+	}
+	info, err := os.Stat(path) // follows symlinks intentionally
+	if err != nil {
+		if !allowAnyExistingFile {
+			// A home-screen query is only hijacked by a real file; a missing
+			// or unreadable path falls through to a normal search.
+			return Target{}, false, nil
+		}
+		if os.IsNotExist(err) {
+			if looksLikeTorrent {
+				return Target{}, true, fmt.Errorf("torrent file not found: %s", path)
+			}
+			return Target{}, false, nil
+		}
+		return Target{}, true, err
+	}
+	if !info.Mode().IsRegular() {
+		return Target{}, true, fmt.Errorf("torrent input is not a regular file: %s", path)
+	}
+	if info.Size() > MaxTorrentBytes {
+		return Target{}, true, fmt.Errorf("torrent file is too large: %s (maximum 16 MiB)", path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return Target{}, true, err
+	}
+	return Target{Kind: TorrentFile, Value: abs, Name: filepath.Base(abs)}, true, nil
+}
+
+func automaticTorrentURL(raw string) (*url.URL, bool) {
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return nil, false
+	}
+	return u, strings.EqualFold(filepath.Ext(u.Path), ".torrent")
+}
+
+func localPath(raw string) (path string, looksLikeTorrent bool) {
+	path = raw
+	if raw == "~" || strings.HasPrefix(raw, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = home
+			if raw != "~" {
+				path = filepath.Join(home, strings.TrimPrefix(raw, "~/"))
+			}
+		}
+	}
+	return filepath.Clean(path), strings.EqualFold(filepath.Ext(path), ".torrent")
+}
+
+func magnetName(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get("dn")
+}
+
+func urlName(u *url.URL) string {
+	name := filepath.Base(u.Path)
+	if dec, err := url.PathUnescape(name); err == nil {
+		name = dec
+	}
+	if name == "." || name == "/" {
+		return ""
+	}
+	return name
+}

--- a/internal/intake/intake_test.go
+++ b/internal/intake/intake_test.go
@@ -1,0 +1,120 @@
+package intake
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectCommonInputs(t *testing.T) {
+	cases := []struct {
+		raw  string
+		kind Kind
+	}{
+		{"magnet:?xt=urn:btih:ABCDEF&dn=My+File", Magnet},
+		{"0123456789abcdef0123456789abcdef01234567", InfoHash},
+		{"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", InfoHash},
+		{"https://example.test/path/My%20File.torrent?download=1", TorrentURL},
+	}
+	for _, tc := range cases {
+		got, ok, err := DetectCLI(tc.raw)
+		if err != nil || !ok || got.Kind != tc.kind {
+			t.Errorf("DetectCLI(%q) = %+v, %v, %v; want kind %v", tc.raw, got, ok, err, tc.kind)
+		}
+	}
+}
+
+func TestDetectLocalFiles(t *testing.T) {
+	dir := t.TempDir()
+	torrentPath := filepath.Join(dir, "sample.torrent")
+	plainPath := filepath.Join(dir, "no-extension")
+	for _, path := range []string{torrentPath, plainPath} {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(dir, "linked.torrent")
+	if err := os.Symlink(torrentPath, link); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{torrentPath, plainPath, link} {
+		got, ok, err := DetectCLI(path)
+		if err != nil || !ok || got.Kind != TorrentFile || !filepath.IsAbs(got.Value) {
+			t.Errorf("DetectCLI(%q) = %+v, %v, %v", path, got, ok, err)
+		}
+	}
+	if _, ok, err := DetectHome(plainPath); err != nil || ok {
+		t.Fatalf("home field classified extensionless local file: ok=%v err=%v", ok, err)
+	}
+	if got, ok, err := DetectHome(torrentPath); err != nil || !ok || got.Kind != TorrentFile {
+		t.Fatalf("DetectHome(.torrent) = %+v, %v, %v", got, ok, err)
+	}
+}
+
+func TestDetectExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, "sample.torrent")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := DetectCLI("~/sample.torrent")
+	if err != nil || !ok || got.Value != path {
+		t.Fatalf("DetectCLI(home) = %+v, %v, %v", got, ok, err)
+	}
+}
+
+func TestDetectResolvesRelativePathFromLaunchDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("relative.torrent", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := DetectCLI("relative.torrent")
+	want := filepath.Join(dir, "relative.torrent")
+	if err != nil || !ok || got.Value != want {
+		t.Fatalf("DetectCLI(relative) = %+v, %v, %v; want %s", got, ok, err, want)
+	}
+}
+
+func TestDetectRejectsBadLocalInputs(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok, err := DetectCLI(filepath.Join(dir, "missing.torrent")); !ok || err == nil {
+		t.Fatalf("missing .torrent = ok=%v err=%v", ok, err)
+	}
+	// The home field must fall back to a normal search for a query that only
+	// looks like a torrent path.
+	if _, ok, err := DetectHome(filepath.Join(dir, "missing.torrent")); ok || err != nil {
+		t.Fatalf("home missing .torrent should search: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := DetectCLI(dir); !ok || err == nil {
+		t.Fatalf("directory = ok=%v err=%v", ok, err)
+	}
+	large := filepath.Join(dir, "large.torrent")
+	f, err := os.Create(large)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(MaxTorrentBytes + 1); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	if _, ok, err := DetectCLI(large); !ok || err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("large file = ok=%v err=%v", ok, err)
+	}
+}
+
+func TestExplicitTorrentURL(t *testing.T) {
+	got, err := ExplicitTorrentURL("https://example.test/download?id=12")
+	if err != nil || got.Kind != TorrentURL {
+		t.Fatalf("ExplicitTorrentURL = %+v, %v", got, err)
+	}
+	if _, err := ExplicitTorrentURL("file:///tmp/a.torrent"); err == nil {
+		t.Fatal("accepted non-http URL")
+	}
+	if _, ok, _ := DetectCLI("https://example.test/download?id=12"); ok {
+		t.Fatal("ambiguous URL was auto-detected")
+	}
+}

--- a/internal/metacache/cache.go
+++ b/internal/metacache/cache.go
@@ -1,0 +1,327 @@
+// Package metacache persists validated torrent metainfo by infohash. It is a
+// derived, bounded cache: corrupt entries may always be discarded safely.
+package metacache
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/melqtx/tork/internal/config"
+	"github.com/melqtx/tork/internal/intake"
+)
+
+const (
+	defaultMaxMB      = 256
+	defaultMaxEntries = 512
+)
+
+type Cache struct {
+	mu         sync.Mutex
+	dir        string
+	enabled    bool
+	maxBytes   int64
+	maxEntries int
+}
+
+type Report struct {
+	Enabled  bool
+	Exists   bool
+	Entries  int
+	Bytes    int64
+	Invalid  int
+	Insecure int
+	Err      error
+}
+
+func New(cfg *config.Config) *Cache {
+	maxMB := cfg.MetadataCache.MaxMB
+	if maxMB < 1 || int64(maxMB) > int64(^uint64(0)>>1)>>20 {
+		maxMB = defaultMaxMB
+	}
+	maxEntries := cfg.MetadataCache.MaxEntries
+	if maxEntries < 1 {
+		maxEntries = defaultMaxEntries
+	}
+	return &Cache{
+		dir: cfg.MetadataCacheDir(), enabled: cfg.MetadataCache.Enabled,
+		maxBytes: int64(maxMB) << 20, maxEntries: maxEntries,
+	}
+}
+
+func (c *Cache) Enabled() bool { return c != nil && c.enabled }
+
+func (c *Cache) Discard(hash metainfo.Hash) {
+	if !c.Enabled() {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_ = os.Remove(c.path(hash))
+}
+
+// Load returns a validated entry. Invalid derived files are removed and
+// treated as misses so peer discovery can continue normally.
+func (c *Cache) Load(hash metainfo.Hash) (*metainfo.MetaInfo, bool) {
+	if !c.Enabled() {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := validateCacheDir(c.dir); err != nil {
+		return nil, false
+	}
+	if runtime.GOOS != "windows" {
+		if info, err := os.Lstat(c.dir); err != nil || info.Mode().Perm()&0o077 != 0 {
+			return nil, false
+		}
+	}
+	path := c.path(hash)
+	mi, err := readValidated(path, hash)
+	if err != nil {
+		if !os.IsNotExist(err) && isInvalid(err) {
+			_ = os.Remove(path)
+		}
+		return nil, false
+	}
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
+	return mi, true
+}
+
+// Store validates and atomically writes one entry, then enforces cache caps.
+func (c *Cache) Store(mi metainfo.MetaInfo) error {
+	if !c.Enabled() {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(mi.InfoBytes) == 0 {
+		return fmt.Errorf("metainfo has no info dictionary")
+	}
+	if _, err := mi.UnmarshalInfo(); err != nil {
+		return fmt.Errorf("invalid info dictionary: %w", err)
+	}
+	var data bytes.Buffer
+	if err := mi.Write(&data); err != nil {
+		return err
+	}
+	if int64(data.Len()) > intake.MaxTorrentBytes {
+		return fmt.Errorf("metainfo exceeds 16 MiB")
+	}
+	if err := ensureCacheDir(c.dir); err != nil {
+		return err
+	}
+	path := c.path(mi.HashInfoBytes())
+	tmp, err := os.CreateTemp(c.dir, ".metainfo-*.torrent")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		if !ok {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data.Bytes()); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	closed = true
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	ok = true
+	return c.prune()
+}
+
+func (c *Cache) path(hash metainfo.Hash) string {
+	return filepath.Join(c.dir, strings.ToLower(hash.HexString())+".torrent")
+}
+
+type invalidError struct{ error }
+
+func isInvalid(err error) bool {
+	_, ok := err.(invalidError)
+	return ok
+}
+
+func readValidated(path string, want metainfo.Hash) (*metainfo.MetaInfo, error) {
+	linkInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if linkInfo.Mode()&os.ModeSymlink != 0 || !linkInfo.Mode().IsRegular() {
+		return nil, invalidError{fmt.Errorf("cache entry is not a regular file")}
+	}
+	if runtime.GOOS != "windows" && linkInfo.Mode().Perm()&0o077 != 0 {
+		return nil, invalidError{fmt.Errorf("cache entry permissions are not private")}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > intake.MaxTorrentBytes {
+		return nil, invalidError{fmt.Errorf("invalid cache entry size or type")}
+	}
+	mi, err := metainfo.Load(io.LimitReader(f, intake.MaxTorrentBytes+1))
+	if err != nil {
+		return nil, invalidError{err}
+	}
+	if len(mi.InfoBytes) == 0 || mi.HashInfoBytes() != want {
+		return nil, invalidError{fmt.Errorf("cache infohash mismatch")}
+	}
+	if _, err := mi.UnmarshalInfo(); err != nil {
+		return nil, invalidError{err}
+	}
+	return mi, nil
+}
+
+type cacheFile struct {
+	path string
+	size int64
+	mod  time.Time
+}
+
+func (c *Cache) prune() error {
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		return err
+	}
+	var files []cacheFile
+	var total int64
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".torrent") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		f := cacheFile{path: filepath.Join(c.dir, entry.Name()), size: info.Size(), mod: info.ModTime()}
+		files = append(files, f)
+		total += f.size
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].mod.Before(files[j].mod) })
+	for len(files) > c.maxEntries || total > c.maxBytes {
+		victim := files[0]
+		files = files[1:]
+		if err := os.Remove(victim.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		total -= victim.size
+	}
+	return nil
+}
+
+// Inspect validates the cache without touching timestamps or deleting files.
+func (c *Cache) Inspect() Report {
+	if c != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+	}
+	rep := Report{Enabled: c.Enabled()}
+	if !rep.Enabled {
+		return rep
+	}
+	dirInfo, err := os.Lstat(c.dir)
+	if os.IsNotExist(err) {
+		return rep
+	}
+	if err != nil {
+		rep.Err = err
+		return rep
+	}
+	rep.Exists = true
+	if dirInfo.Mode()&os.ModeSymlink != 0 || !dirInfo.IsDir() {
+		rep.Err = fmt.Errorf("cache path is not a directory")
+		return rep
+	}
+	if runtime.GOOS != "windows" && dirInfo.Mode().Perm()&0o077 != 0 {
+		rep.Insecure++
+	}
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		rep.Err = err
+		return rep
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".torrent") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			rep.Invalid++
+			continue
+		}
+		rep.Entries++
+		rep.Bytes += info.Size()
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+			rep.Insecure++
+		}
+		hashHex := strings.TrimSuffix(strings.ToLower(entry.Name()), ".torrent")
+		var hash metainfo.Hash
+		if err := hash.FromHexString(hashHex); err != nil {
+			rep.Invalid++
+			continue
+		}
+		if _, err := readValidated(filepath.Join(c.dir, entry.Name()), hash); err != nil {
+			rep.Invalid++
+		}
+	}
+	return rep
+}
+
+func ensureCacheDir(dir string) error {
+	err := validateCacheDir(dir)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		err = validateCacheDir(dir)
+	}
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS != "windows" {
+		return os.Chmod(dir, 0o700)
+	}
+	return nil
+}
+
+func validateCacheDir(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("metadata cache path is not a regular directory")
+	}
+	return nil
+}

--- a/internal/metacache/cache_test.go
+++ b/internal/metacache/cache_test.go
@@ -1,0 +1,251 @@
+package metacache
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/melqtx/tork/internal/config"
+)
+
+func testMetaInfo(t *testing.T, name string) metainfo.MetaInfo {
+	t.Helper()
+	info := metainfo.Info{Name: name, PieceLength: 16 << 10, Length: 1}
+	infoBytes, err := bencode.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return metainfo.MetaInfo{InfoBytes: infoBytes, Announce: "https://tracker.example/announce"}
+}
+
+func testCache(t *testing.T) (*Cache, *config.Config) {
+	t.Helper()
+	cfg := config.Default(t.TempDir())
+	return New(cfg), cfg
+}
+
+func TestStoreLoadAndPermissions(t *testing.T) {
+	cache, cfg := testCache(t)
+	mi := testMetaInfo(t, "cached.bin")
+	if err := cache.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := cache.Load(mi.HashInfoBytes())
+	if !ok || !bytes.Equal(got.InfoBytes, mi.InfoBytes) {
+		t.Fatalf("Load = %+v, %v", got, ok)
+	}
+	if runtime.GOOS != "windows" {
+		dirInfo, _ := os.Stat(cfg.MetadataCacheDir())
+		fileInfo, _ := os.Stat(cache.path(mi.HashInfoBytes()))
+		if dirInfo.Mode().Perm() != 0o700 || fileInfo.Mode().Perm() != 0o600 {
+			t.Fatalf("modes = dir %o file %o", dirInfo.Mode().Perm(), fileInfo.Mode().Perm())
+		}
+	}
+}
+
+func TestInvalidEntryIsRemoved(t *testing.T) {
+	cache, _ := testCache(t)
+	mi := testMetaInfo(t, "bad.bin")
+	path := cache.path(mi.HashInfoBytes())
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not metainfo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.Load(mi.HashInfoBytes()); ok {
+		t.Fatal("loaded corrupt cache entry")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("corrupt entry was not removed: %v", err)
+	}
+}
+
+func TestHashMismatchIsRemoved(t *testing.T) {
+	cache, _ := testCache(t)
+	a := testMetaInfo(t, "a.bin")
+	b := testMetaInfo(t, "b.bin")
+	if err := cache.Store(a); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(cache.path(a.HashInfoBytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPath := cache.path(b.HashInfoBytes())
+	if err := os.WriteFile(wrongPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.Load(b.HashInfoBytes()); ok {
+		t.Fatal("loaded mismatched cache entry")
+	}
+	if _, err := os.Stat(wrongPath); !os.IsNotExist(err) {
+		t.Fatalf("mismatched entry was not removed: %v", err)
+	}
+}
+
+func TestPruneUsesLeastRecentlyUsedEntry(t *testing.T) {
+	cache, _ := testCache(t)
+	cache.maxEntries = 2
+	items := []metainfo.MetaInfo{
+		testMetaInfo(t, "old.bin"), testMetaInfo(t, "middle.bin"), testMetaInfo(t, "new.bin"),
+	}
+	for i, mi := range items {
+		if err := cache.Store(mi); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(time.Duration(i-10) * time.Hour)
+		if err := os.Chtimes(cache.path(mi.HashInfoBytes()), at, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := cache.prune(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(cache.path(items[0].HashInfoBytes())); !os.IsNotExist(err) {
+		t.Fatalf("oldest entry survived prune: %v", err)
+	}
+	for _, mi := range items[1:] {
+		if _, err := os.Stat(cache.path(mi.HashInfoBytes())); err != nil {
+			t.Fatalf("newer entry missing: %v", err)
+		}
+	}
+}
+
+func TestLoadRefreshesRecency(t *testing.T) {
+	cache, _ := testCache(t)
+	cache.maxEntries = 2
+	a := testMetaInfo(t, "a.bin")
+	b := testMetaInfo(t, "b.bin")
+	c := testMetaInfo(t, "c.bin")
+	for _, mi := range []metainfo.MetaInfo{a, b} {
+		if err := cache.Store(mi); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	newer := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(cache.path(a.HashInfoBytes()), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(cache.path(b.HashInfoBytes()), newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.Load(a.HashInfoBytes()); !ok {
+		t.Fatal("cache hit failed")
+	}
+	if err := cache.Store(c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(cache.path(b.HashInfoBytes())); !os.IsNotExist(err) {
+		t.Fatalf("untouched entry survived LRU prune: %v", err)
+	}
+	for _, mi := range []metainfo.MetaInfo{a, c} {
+		if _, err := os.Stat(cache.path(mi.HashInfoBytes())); err != nil {
+			t.Fatalf("recent entry missing: %v", err)
+		}
+	}
+}
+
+func TestPruneEnforcesByteLimit(t *testing.T) {
+	cache, _ := testCache(t)
+	cache.maxBytes = 1
+	mi := testMetaInfo(t, "too-big-for-cache-cap.bin")
+	if err := cache.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(cache.path(mi.HashInfoBytes())); !os.IsNotExist(err) {
+		t.Fatalf("byte cap did not prune entry: %v", err)
+	}
+}
+
+func TestStoreRejectsOversizedMetainfo(t *testing.T) {
+	cache, _ := testCache(t)
+	mi := testMetaInfo(t, "oversized.bin")
+	mi.Comment = string(make([]byte, (16<<20)+1))
+	if err := cache.Store(mi); err == nil {
+		t.Fatal("stored oversized metainfo")
+	}
+	if _, err := os.Stat(cache.path(mi.HashInfoBytes())); !os.IsNotExist(err) {
+		t.Fatalf("oversized metainfo left a cache entry: %v", err)
+	}
+}
+
+func TestInspectIsReadOnly(t *testing.T) {
+	cache, cfg := testCache(t)
+	mi := testMetaInfo(t, "inspect.bin")
+	if err := cache.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	path := cache.path(mi.HashInfoBytes())
+	before, _ := os.Stat(path)
+	rep := New(cfg).Inspect()
+	after, _ := os.Stat(path)
+	if rep.Entries != 1 || rep.Invalid != 0 || rep.Err != nil {
+		t.Fatalf("Inspect = %+v", rep)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("Inspect touched cache recency")
+	}
+}
+
+func TestInspectReportsInsecurePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows permissions are ACL-based")
+	}
+	cache, _ := testCache(t)
+	mi := testMetaInfo(t, "permissions.bin")
+	if err := cache.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cache.path(mi.HashInfoBytes()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rep := cache.Inspect()
+	if rep.Insecure != 1 {
+		t.Fatalf("Inspect = %+v, want one insecure file", rep)
+	}
+	info, _ := os.Stat(cache.path(mi.HashInfoBytes()))
+	if info.Mode().Perm() != 0o644 {
+		t.Fatal("Inspect repaired permissions")
+	}
+}
+
+func TestStoreRefusesSymlinkedCacheDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation commonly requires elevated privileges")
+	}
+	cache, cfg := testCache(t)
+	outside := t.TempDir()
+	if err := os.Symlink(outside, cfg.MetadataCacheDir()); err != nil {
+		t.Fatal(err)
+	}
+	mi := testMetaInfo(t, "escape.bin")
+	if err := cache.Store(mi); err == nil {
+		t.Fatal("stored through symlinked cache directory")
+	}
+	if entries, err := os.ReadDir(outside); err != nil || len(entries) != 0 {
+		t.Fatalf("outside directory changed: %v, %v", entries, err)
+	}
+}
+
+func TestDisabledCacheDoesNothing(t *testing.T) {
+	cfg := config.Default(t.TempDir())
+	cfg.MetadataCache.Enabled = false
+	cache := New(cfg)
+	mi := testMetaInfo(t, "disabled.bin")
+	if err := cache.Store(mi); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cache.Load(mi.HashInfoBytes()); ok {
+		t.Fatal("disabled cache returned a hit")
+	}
+	if _, err := os.Stat(cfg.MetadataCacheDir()); !os.IsNotExist(err) {
+		t.Fatalf("disabled cache created files: %v", err)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -44,6 +44,7 @@ type App struct {
 	compass    compassModel
 	proxy      proxyBadge
 	proxyCheck proxyChecker
+	startup    tea.Cmd // optional one-shot action requested on the command line
 
 	errText      string
 	lastTickSave time.Time // throttles progress-only state.json writes on the tick
@@ -81,6 +82,10 @@ func (a *App) Init() tea.Cmd {
 	}
 	if proxyCmd := a.startProxyCheck(time.Now()); proxyCmd != nil {
 		cmds = append(cmds, proxyCmd)
+	}
+	if a.startup != nil {
+		cmds = append(cmds, a.startup)
+		a.startup = nil
 	}
 	return tea.Batch(cmds...)
 }

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -158,14 +158,14 @@ func newResultsLayout(width int) resultsLayout {
 	return l
 }
 
-// previewLayout: gutter box icon name · risk · bar · size.
+// previewLayout: gutter checkbox icon name · risk · bar · size.
 type previewLayout struct {
 	nameW, barW, sizeW int
 }
 
 func newPreviewLayout(width int) previewLayout {
 	l := previewLayout{barW: 8, sizeW: 10}
-	l.nameW = flexW(width, 16, 1+2+2+2+l.barW+1+l.sizeW)
+	l.nameW = flexW(width, 16, 3+2+2+2+l.barW+1+l.sizeW)
 	return l
 }
 

--- a/internal/tui/preview.go
+++ b/internal/tui/preview.go
@@ -17,21 +17,25 @@ import (
 // previewModel is the magnet sandbox: inspect a torrent's files and choose
 // which to download before any data transfers.
 type previewModel struct {
-	hash     metainfo.Hash
-	magnet   string
-	name     string
-	from     screen
-	owned    bool
-	files    []engine.FileInfo
-	tree     *fileNode
-	rows     []*fileNode
-	ready    bool
-	excluded map[int]bool // keyed by FileInfo.Index
-	win      listWindow
+	hash      metainfo.Hash
+	magnet    string
+	name      string
+	from      screen
+	owned     bool
+	files     []engine.FileInfo
+	tree      *fileNode
+	rows      []*fileNode
+	ready     bool
+	startedAt time.Time
+	excluded  map[int]bool // keyed by FileInfo.Index
+	win       listWindow
 }
 
 func newPreviewModel(h metainfo.Hash, magnet, name string, from screen, owned bool) previewModel {
-	return previewModel{hash: h, magnet: magnet, name: previewName(magnet, name), from: from, owned: owned, excluded: map[int]bool{}}
+	return previewModel{
+		hash: h, magnet: magnet, name: previewName(magnet, name), from: from,
+		owned: owned, startedAt: time.Now(), excluded: map[int]bool{},
+	}
 }
 
 // refresh polls the engine for file metadata once it arrives.
@@ -99,7 +103,13 @@ func (a *App) updatePreview(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	if !p.ready {
-		return a, nil // ignore edits until the file list is known
+		// Metadata can take a while for a bare hash because a peer must supply
+		// it. Enter lets the user approve the whole torrent now and watch peer
+		// discovery from Downloads; waiting preserves file-by-file selection.
+		if key.String() == "enter" && p.hash != (metainfo.Hash{}) {
+			return a, a.startPreviewDownload()
+		}
+		return a, nil
 	}
 	rows := a.previewRows()
 	switch key.String() {
@@ -249,19 +259,42 @@ func (a *App) viewPreview() string {
 	width := a.contentWidth()
 
 	if !p.ready {
+		waited := time.Since(p.startedAt).Round(time.Second)
+		status, hasStatus := a.eng.MetadataDiscovery(p.hash)
+		if hasStatus && status.Waiting > 0 {
+			waited = status.Waiting.Round(time.Second)
+		}
+		if waited < 0 {
+			waited = 0
+		}
+		discovery := waited.String()
+		if hasStatus && status.Summary() != "" {
+			discovery = status.Summary()
+		}
+		detail := styleFaint.Render("needs a peer with metadata; may take a moment")
+		if waited >= 10*time.Second {
+			detail = styleFaint.Render("still looking; press enter to queue the whole torrent now")
+		}
 		msg := lipgloss.JoinVertical(lipgloss.Center,
 			styleFg.Render(truncate(p.name, width-4)),
 			"",
-			styleDim.Render("fetching metadata…")+styleFaint.Render("  (needs peers; may take a moment)"),
+			styleDim.Render("finding metadata peers…"),
+			styleFaint.Render(discovery),
+			detail,
 		)
 		body := lipgloss.Place(width, a.bodyHeight(), lipgloss.Center, lipgloss.Center, msg)
-		return a.chrome("preview", body, hints(hint("esc", "cancel")))
+		return a.chrome("preview", body, hints(hint("enter", "queue all now"), hint("esc", "cancel")))
 	}
 
 	var b strings.Builder
-	b.WriteString(" " + styleFg.Render(truncate(p.name, max(20, width-40))) +
+	source := ""
+	if status, ok := a.eng.MetadataDiscovery(p.hash); ok && status.SourceLabel() != "" {
+		source = styleFaint.Render(" · " + status.SourceLabel())
+	}
+	nameWidth := max(12, width-40-lipgloss.Width(source))
+	b.WriteString(" " + styleFg.Render(truncate(p.name, nameWidth)) +
 		styleFaint.Render(fmt.Sprintf("   %d files · %d dirs", len(p.files), countDirs(p.tree))) +
-		styleFaint.Render(" · total ") + styleDim.Render(humanBytes(p.totalBytes())) + "\n")
+		styleFaint.Render(" · total ") + styleDim.Render(humanBytes(p.totalBytes())) + source + "\n")
 	flagged := ""
 	if n := p.flaggedCount(); n > 0 {
 		flagged = styleFaint.Render(" · ") + styleHealthMid.Render(fmt.Sprintf("⚠ %d flagged", n))
@@ -325,11 +358,11 @@ func (p *previewModel) selectedFiles() int {
 func (p *previewModel) checkbox(n *fileNode) string {
 	switch nodeCheck(n, p.excluded) {
 	case checkAll:
-		return styleOK.Render("◉")
+		return styleOK.Render("[✓]")
 	case checkMixed:
-		return styleHealthMid.Render("◐")
+		return styleHealthMid.Render("[-]")
 	default:
-		return styleFaint.Render("○")
+		return styleFaint.Render("[ ]")
 	}
 }
 

--- a/internal/tui/preview_test.go
+++ b/internal/tui/preview_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,30 +10,112 @@ import (
 
 	"github.com/melqtx/tork/internal/config"
 	"github.com/melqtx/tork/internal/engine"
+	"github.com/melqtx/tork/internal/intake"
+	"github.com/melqtx/tork/internal/state"
 )
 
-func TestDetectMagnetInput(t *testing.T) {
+func TestDetectTorrentInput(t *testing.T) {
 	cases := []struct {
 		in       string
 		ok       bool
-		kind     magnetInputKind
+		kind     intake.Kind
 		name     string
 		contains string
 	}{
-		{"magnet:?xt=urn:btih:ABCDEF&dn=My+File", true, magnetInputMagnet, "My File", "magnet:?"},
-		{"0123456789abcdef0123456789abcdef01234567", true, magnetInputInfoHash, "", "magnet:?xt=urn:btih:"},
-		{"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", true, magnetInputInfoHash, "", "magnet:?xt=urn:btih:"},
-		{"https://example.test/path/My%20File.torrent", true, magnetInputTorrentURL, "My File.torrent", "https://"},
+		{"magnet:?xt=urn:btih:ABCDEF&dn=My+File", true, intake.Magnet, "My File", "magnet:?"},
+		{"0123456789abcdef0123456789abcdef01234567", true, intake.InfoHash, "", "magnet:?xt=urn:btih:"},
+		{"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", true, intake.InfoHash, "", "magnet:?xt=urn:btih:"},
+		{"https://example.test/path/My%20File.torrent", true, intake.TorrentURL, "My File.torrent", "https://"},
 		{"dune 2024", false, 0, "", ""},
 	}
 	for _, c := range cases {
-		target, name, kind, ok := detectMagnetInput(c.in)
-		if ok != c.ok || kind != c.kind || name != c.name {
-			t.Errorf("detectMagnetInput(%q) = (%q,%q,%v,%v), want ok=%v kind=%v name=%q", c.in, target, name, kind, ok, c.ok, c.kind, c.name)
+		target, ok, err := intake.DetectHome(c.in)
+		if err != nil || ok != c.ok || target.Kind != c.kind || target.Name != c.name {
+			t.Errorf("DetectHome(%q) = (%+v,%v,%v), want ok=%v kind=%v name=%q", c.in, target, ok, err, c.ok, c.kind, c.name)
 		}
-		if c.contains != "" && !strings.Contains(target, c.contains) {
-			t.Errorf("target %q does not contain %q", target, c.contains)
+		if c.contains != "" && !strings.Contains(target.Value, c.contains) {
+			t.Errorf("target %q does not contain %q", target.Value, c.contains)
 		}
+	}
+}
+
+func TestOpenTorrentQueuesStartupPreview(t *testing.T) {
+	cfg, err := config.LoadFrom(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := New(cfg, nil, nil, &state.State{}, nil)
+	magnet := "magnet:?xt=urn:btih:1111111111111111111111111111111111111111&dn=Quiet+Launch"
+	if err := a.OpenTorrent(magnet); err != nil {
+		t.Fatal(err)
+	}
+	if a.startup == nil {
+		t.Fatal("OpenTorrent did not queue a startup preview")
+	}
+	if got := a.search.input.Value(); got != magnet {
+		t.Fatalf("search input = %q, want original magnet", got)
+	}
+	if err := a.OpenTorrent("not a torrent"); err == nil {
+		t.Fatal("OpenTorrent accepted ordinary search text")
+	}
+	local := filepath.Join(t.TempDir(), "local.torrent")
+	if err := os.WriteFile(local, []byte("metainfo is decoded by the engine command"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.OpenTorrent(local); err != nil {
+		t.Fatal(err)
+	}
+	if a.startup == nil {
+		t.Fatal("OpenTorrent did not queue local file preview")
+	}
+}
+
+func TestPreviewCheckboxDoesNotDuplicateISOIcon(t *testing.T) {
+	p := previewModel{
+		files:    []engine.FileInfo{{Index: 0, Path: "archlinux.iso", Length: 1}},
+		excluded: map[int]bool{},
+	}
+	n := &fileNode{name: "archlinux.iso", fileIdx: 0, length: 1}
+	if got := p.checkbox(n); !strings.Contains(got, "[✓]") {
+		t.Fatalf("selected checkbox = %q, want an explicit check mark", got)
+	}
+	if got := p.renderNode(n, newPreviewLayout(100), 1); strings.Count(got, "◉") != 1 {
+		t.Fatalf("ISO row = %q, want exactly one disc icon", got)
+	}
+}
+
+func TestEnterQueuesMagnetBeforeMetadataArrives(t *testing.T) {
+	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	magnet := "magnet:?xt=urn:btih:9999999999999999999999999999999999999999"
+	h, owned, err := eng.AddForPreview(magnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &App{
+		cfg: cfg, eng: eng, st: &state.State{}, screen: screenPreview,
+		preview: newPreviewModel(h, magnet, "", screenSearch, owned),
+	}
+	if a.preview.ready {
+		t.Fatal("test torrent unexpectedly has metadata")
+	}
+	if _, cmd := a.updatePreview(tea.KeyMsg{Type: tea.KeyEnter}); cmd == nil {
+		t.Fatal("enter while waiting for metadata returned no queue command")
+	}
+	if a.screen != screenDownloads || len(a.st.Entries) != 1 {
+		t.Fatalf("screen = %v, state = %+v; want queued download", a.screen, a.st)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State == engine.StatePreviewing {
+		t.Fatalf("snapshot = %+v, ok=%v; torrent remained preview-only", snap, ok)
 	}
 }
 

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -304,7 +304,21 @@ func (a *App) launchTorrentURLPreviewCmd(rawURL, name string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		h, metaName, magnet, owned, err := a.eng.AddTorrentURLForPreview(ctx, rawURL)
-		if name == "" {
+		if metaName != "" {
+			name = metaName
+		}
+		return previewReadyMsg{hash: h, magnet: magnet, name: name, from: from, owned: owned, err: err}
+	}
+}
+
+func (a *App) launchTorrentFilePreviewCmd(path, name string) tea.Cmd {
+	from := a.screen
+	return func() (msg tea.Msg) {
+		defer guard(&msg, func(r any) tea.Msg {
+			return previewReadyMsg{magnet: path, name: name, from: from, err: fmt.Errorf("add panicked: %v", r)}
+		})
+		h, metaName, magnet, owned, err := a.eng.AddTorrentFileForPreview(path)
+		if metaName != "" {
 			name = metaName
 		}
 		return previewReadyMsg{hash: h, magnet: magnet, name: name, from: from, owned: owned, err: err}

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -3,16 +3,13 @@ package tui
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"path"
-	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/melqtx/tork/internal/provider"
+	"github.com/melqtx/tork/internal/intake"
 )
 
 // homeDest is a destination on the front-page menu.
@@ -33,8 +30,8 @@ type searchModel struct {
 
 func newSearchModel() searchModel {
 	ti := textinput.New()
-	ti.Placeholder = "search movies, shows, anime, software… or paste a magnet link"
-	ti.CharLimit = 200
+	ti.Placeholder = "search anything… or paste a magnet / .torrent path"
+	ti.CharLimit = 4096 // tracker-rich magnets and long local paths are valid inputs
 	ti.Width = 50
 	ti.Prompt = "❯ "
 	ti.PromptStyle = styleBrand
@@ -44,52 +41,34 @@ func newSearchModel() searchModel {
 	return searchModel{input: ti}
 }
 
-type magnetInputKind int
-
-const (
-	magnetInputMagnet magnetInputKind = iota
-	magnetInputInfoHash
-	magnetInputTorrentURL
-)
-
-var (
-	reHexInfoHash    = regexp.MustCompile(`(?i)^[0-9a-f]{40}$`)
-	reBase32InfoHash = regexp.MustCompile(`(?i)^[a-z2-7]{32}$`)
-)
-
-func detectMagnetInput(query string) (target, name string, kind magnetInputKind, ok bool) {
-	query = strings.TrimSpace(query)
-	lower := strings.ToLower(query)
-	if strings.HasPrefix(lower, "magnet:?") {
-		return query, magnetDisplayName(query), magnetInputMagnet, true
-	}
-	if reHexInfoHash.MatchString(query) || reBase32InfoHash.MatchString(query) {
-		return provider.BuildMagnet(query, "", provider.DefaultTrackers), "", magnetInputInfoHash, true
-	}
-	u, err := url.Parse(query)
-	if err == nil && (u.Scheme == "http" || u.Scheme == "https") && strings.HasSuffix(strings.ToLower(u.Path), ".torrent") {
-		return query, torrentURLName(u), magnetInputTorrentURL, true
-	}
-	return "", "", 0, false
-}
-
-func magnetDisplayName(mag string) string {
-	u, err := url.Parse(mag)
+// OpenTorrent arranges for any supported explicit CLI input to open in the
+// same quiet preview flow as pasting it on the home screen.
+func (a *App) OpenTorrent(raw string) error {
+	target, ok, err := intake.DetectCLI(raw)
 	if err != nil {
-		return ""
+		return err
 	}
-	return u.Query().Get("dn")
+	if !ok {
+		return fmt.Errorf("expected a magnet link, infohash, torrent URL, or local torrent file")
+	}
+	return a.OpenTarget(target)
+
 }
 
-func torrentURLName(u *url.URL) string {
-	name := path.Base(u.Path)
-	if dec, err := url.PathUnescape(name); err == nil {
-		name = dec
+// OpenTarget queues a previously classified input for the first TUI frame.
+func (a *App) OpenTarget(target intake.Target) error {
+	a.search.input.SetValue(target.Value)
+	switch target.Kind {
+	case intake.Magnet, intake.InfoHash:
+		a.startup = a.launchCmd(target.Value, target.Name, true)
+	case intake.TorrentURL:
+		a.startup = a.launchTorrentURLPreviewCmd(target.Value, target.Name)
+	case intake.TorrentFile:
+		a.startup = a.launchTorrentFilePreviewCmd(target.Value, target.Name)
+	default:
+		return fmt.Errorf("unsupported torrent input")
 	}
-	if name == "." || name == "/" {
-		return ""
-	}
-	return name
+	return nil
 }
 
 func (a *App) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -105,11 +84,20 @@ func (a *App) updateSearch(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch key.String() {
 	case "enter":
 		if query := strings.TrimSpace(a.search.input.Value()); query != "" {
-			if target, name, kind, ok := detectMagnetInput(query); ok {
-				if kind == magnetInputTorrentURL {
-					return a, a.launchTorrentURLPreviewCmd(target, name)
+			target, detected, err := intake.DetectHome(query)
+			if err != nil {
+				a.errText = err.Error()
+				return a, clearErrCmd()
+			}
+			if detected {
+				switch target.Kind {
+				case intake.TorrentURL:
+					return a, a.launchTorrentURLPreviewCmd(target.Value, target.Name)
+				case intake.TorrentFile:
+					return a, a.launchTorrentFilePreviewCmd(target.Value, target.Name)
+				default:
+					return a, a.launchCmd(target.Value, target.Name, true)
 				}
-				return a, a.launchCmd(target, name, true)
 			}
 			return a, a.startSearch(query)
 		}


### PR DESCRIPTION
## What changed

- Accept magnets, infohashes, local torrent files, and torrent URLs directly.
- Cache validated metainfo with bounded storage and strict filesystem checks.
- Make autopilot plans explainable, constrained, confirmed, and locally auditable.
- Improve metadata discovery status, early queueing, cache diagnostics, and HTTP size limits.
