### PR TITLE
Add Finder reveal and copy-path actions for downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # compiled binary
 /tork
+/bin/
 
 # backups tork writes when it recovers corrupt state
 *.bak

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ manual check.
 - **home** type to search, `↑↓` pick a destination, `enter` go
 - **isos** `↑↓` browse, `enter` grab the latest official image
 - **results** `enter` preview/get, `D` grab now, `/` filter, `o` sort, `v` graph
-- **downloads** `p` pause/resume, `s` seed, `v` verify, `m` move, `r` relink, `x` remove, `d` delete data, `o` reveal in Finder (macOS)
+- **downloads** `p` pause/resume, `s` seed, `v` verify, `m` move, `r` relink, `y` copy full path, `x` remove, `d` delete data, `o` reveal in Finder (macOS)
 - `tab` cycle, `esc` back, `^c` quit
 
 ## Autopilot (WIP)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ If Go on macOS is picking Nix's compiler, use Apple Clang for the install:
 CC=/usr/bin/clang CXX=/usr/bin/clang++ go install github.com/melqtx/tork/cmd/tork@latest
 ```
 
+## Build from source
+
+Building tork requires Go 1.26 or newer. From the repository root, run it
+directly without creating a binary:
+
+```sh
+go run ./cmd/tork
+```
+
+Or build and run a local binary:
+
+```sh
+go build -o ./bin/tork ./cmd/tork
+./bin/tork
+```
+
 Config lives in `~/.tork/`; downloads land in `~/Downloads/tork` (change with
 `tork -d DIR`).
 
@@ -138,7 +154,7 @@ manual check.
 - **home** type to search, `↑↓` pick a destination, `enter` go
 - **isos** `↑↓` browse, `enter` grab the latest official image
 - **results** `enter` preview/get, `D` grab now, `/` filter, `o` sort, `v` graph
-- **downloads** `p` pause/resume, `s` seed, `v` verify, `m` move, `r` relink, `x` remove, `d` delete data
+- **downloads** `p` pause/resume, `s` seed, `v` verify, `m` move, `r` relink, `x` remove, `d` delete data, `o` reveal in Finder (macOS)
 - `tab` cycle, `esc` back, `^c` quit
 
 ## Autopilot (WIP)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/anacrolix/log v0.17.1-0.20251118025802-918f1157b7bb
 	github.com/anacrolix/torrent v1.61.0
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -37,7 +38,6 @@ require (
 	github.com/anacrolix/utp v0.1.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/immutable v0.4.1-0.20221220213129-8932b999621d // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -139,6 +139,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.errText = ""
 		return a, nil
 
+	case revealDownloadMsg:
+		if msg.err != nil {
+			a.errText = msg.err.Error()
+			return a, clearErrCmd()
+		}
+		return a, nil
+
 	case healthDoneMsg:
 		return a, a.onHealthDone(msg)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -146,6 +146,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return a, nil
 
+	case copyDownloadPathMsg:
+		if msg.err != nil {
+			a.errText = msg.err.Error()
+			return a, clearErrCmd()
+		}
+		return a, nil
+
 	case healthDoneMsg:
 		return a, a.onHealthDone(msg)
 

--- a/internal/tui/downloads.go
+++ b/internal/tui/downloads.go
@@ -3,7 +3,9 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -16,6 +18,8 @@ import (
 	"github.com/melqtx/tork/internal/engine"
 	"github.com/melqtx/tork/internal/state"
 )
+
+const finderRevealAvailable = runtime.GOOS == "darwin"
 
 type downloadItem struct {
 	Hash           metainfo.Hash
@@ -40,6 +44,8 @@ type removeConfirm struct {
 	item       downloadItem
 	deleteData bool
 }
+
+type revealDownloadMsg struct{ err error }
 
 type pathAction int
 
@@ -142,8 +148,29 @@ func (a *App) updateDownloads(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if it, ok := a.selectedDownload(items); ok {
 			d.confirmRemove = &removeConfirm{item: it, deleteData: true}
 		}
+	case "o":
+		if finderRevealAvailable {
+			it, ok := a.selectedDownload(items)
+			if !ok {
+				break
+			}
+			return a, revealDownload(it)
+		}
 	}
 	return a, nil
+}
+
+func revealDownload(it downloadItem) tea.Cmd {
+	return func() tea.Msg {
+		path := strings.TrimSpace(it.DataPath)
+		if path == "" {
+			return revealDownloadMsg{err: fmt.Errorf("reveal needs a known saved path")}
+		}
+		if err := exec.Command("open", "-R", path).Run(); err != nil {
+			return revealDownloadMsg{err: fmt.Errorf("reveal failed: %w", err)}
+		}
+		return revealDownloadMsg{}
+	}
 }
 
 func newPathPrompt(action pathAction, it downloadItem, prompt, value string) pathPrompt {
@@ -612,7 +639,11 @@ func (a *App) viewDownloads() string {
 		b.WriteString("\n" + rule(width) + "\n" + detail)
 	}
 
-	help := hints(hint("↑↓", "move"), hint("p", "pause"), hint("s", "seed"), hint("v", "verify"), hint("m", "move"), hint("r", "relink"), hint("x", "remove"), hint("d", "delete"), hint("H", "health"), hint("esc", "search"))
+	helpParts := []string{hint("↑↓", "move"), hint("p", "pause"), hint("s", "seed"), hint("v", "verify"), hint("m", "move"), hint("r", "relink"), hint("x", "remove"), hint("d", "delete"), hint("H", "health"), hint("esc", "search")}
+	if finderRevealAvailable {
+		helpParts = append(helpParts, hint("o", "reveal"))
+	}
+	help := hints(helpParts...)
 	if d.confirmRemove != nil {
 		verb := "remove from list"
 		if d.confirmRemove.deleteData {
@@ -675,12 +706,16 @@ func (a *App) downloadDetail(it downloadItem, width int) string {
 	if it.Seed {
 		seed = "on"
 	}
+	keys := "m move folder · r relink existing files · d delete data"
+	if finderRevealAvailable {
+		keys += " · o reveal in Finder"
+	}
 	lines := []string{
 		styleFaint.Render("path  ") + styleDim.Render(truncate(path, width-7)),
 		styleFaint.Render("root  ") + styleDim.Render(truncate(it.DownloadDir, width-7)),
 		styleFaint.Render("seed  ") + styleDim.Render(seed) + styleFaint.Render("   status  ") + stateBadge(it.State),
 		styleFaint.Render("size  ") + styleDim.Render(fmt.Sprintf("%s selected", humanBytes(it.Length))),
-		styleFaint.Render("keys  ") + styleDim.Render("m move folder · r relink existing files · d delete data"),
+		styleFaint.Render("keys  ") + styleDim.Render(keys),
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/downloads.go
+++ b/internal/tui/downloads.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aymanbagabas/go-osc52/v2"
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -46,6 +47,8 @@ type removeConfirm struct {
 }
 
 type revealDownloadMsg struct{ err error }
+
+type copyDownloadPathMsg struct{ err error }
 
 type pathAction int
 
@@ -140,6 +143,10 @@ func (a *App) updateDownloads(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d.prompt = newPathPrompt(pathActionRelink, it, "existing path: ", it.DataPath)
 			return a, d.prompt.input.Focus()
 		}
+	case "y":
+		if it, ok := a.selectedDownload(items); ok {
+			return a, copyDownloadPath(it)
+		}
 	case "x":
 		if it, ok := a.selectedDownload(items); ok {
 			d.confirmRemove = &removeConfirm{item: it}
@@ -158,6 +165,33 @@ func (a *App) updateDownloads(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 	return a, nil
+}
+
+func copyDownloadPath(it downloadItem) tea.Cmd {
+	return func() tea.Msg {
+		path := strings.TrimSpace(it.DataPath)
+		if path == "" {
+			return copyDownloadPathMsg{err: fmt.Errorf("copy needs a known saved path")}
+		}
+
+		seq := pathClipboardSequence(path)
+		if _, err := seq.WriteTo(os.Stdout); err != nil {
+			return copyDownloadPathMsg{err: fmt.Errorf("copy path failed: %w", err)}
+		}
+		return copyDownloadPathMsg{}
+	}
+}
+
+func pathClipboardSequence(path string) osc52.Sequence {
+	seq := osc52.New(path)
+	switch {
+	case os.Getenv("TMUX") != "":
+		return seq.Tmux()
+	case os.Getenv("STY") != "":
+		return seq.Screen()
+	default:
+		return seq
+	}
 }
 
 func revealDownload(it downloadItem) tea.Cmd {
@@ -639,7 +673,7 @@ func (a *App) viewDownloads() string {
 		b.WriteString("\n" + rule(width) + "\n" + detail)
 	}
 
-	helpParts := []string{hint("↑↓", "move"), hint("p", "pause"), hint("s", "seed"), hint("v", "verify"), hint("m", "move"), hint("r", "relink"), hint("x", "remove"), hint("d", "delete"), hint("H", "health"), hint("esc", "search")}
+	helpParts := []string{hint("↑↓", "move"), hint("p", "pause"), hint("s", "seed"), hint("v", "verify"), hint("m", "move"), hint("r", "relink"), hint("y", "copy path"), hint("x", "remove"), hint("d", "delete"), hint("H", "health"), hint("esc", "search")}
 	if finderRevealAvailable {
 		helpParts = append(helpParts, hint("o", "reveal"))
 	}
@@ -706,7 +740,7 @@ func (a *App) downloadDetail(it downloadItem, width int) string {
 	if it.Seed {
 		seed = "on"
 	}
-	keys := "m move folder · r relink existing files · d delete data"
+	keys := "m move folder · r relink existing files · y copy full path · d delete data"
 	if finderRevealAvailable {
 		keys += " · o reveal in Finder"
 	}

--- a/internal/tui/downloads_test.go
+++ b/internal/tui/downloads_test.go
@@ -94,3 +94,14 @@ func TestMovePayloadMovesPartFileRoundTrip(t *testing.T) {
 		t.Fatalf("moved part = %q", got)
 	}
 }
+
+func TestPathClipboardSequenceCopiesFullPath(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("STY", "")
+
+	got := pathClipboardSequence("/home/cat/Downloads/image.iso").String()
+	want := "\x1b]52;c;L2hvbWUvY2F0L0Rvd25sb2Fkcy9pbWFnZS5pc28=\x07"
+	if got != want {
+		t.Fatalf("clipboard sequence = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

* add `o` to reveal the selected download in Finder on macOS
* add `y` to copy the selected download's saved path to the terminal clipboard using OSC 52
* wrap OSC 52 sequences for tmux and GNU Screen
* show the new shortcuts in the downloads view
* report missing paths and action failures in the TUI

## Other changes

* document how to run and build tork from source
* ignore binaries built under `./bin`

## Testing

* `go test ./internal/tui`
* added a test for generating an OSC 52 sequence containing the full download path

I'm open to alternative approaches if they fit the project better