### PR TITLE
fix: verify completed downloads and recover corrupt data

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,10 @@ manual check.
 - **home** type to search, `↑↓` pick a destination, `enter` go
 - **isos** `↑↓` browse, `enter` grab the latest official image
 - **results** `enter` preview/get, `D` grab now, `Y` copy magnet, `/` filter, `o` sort, `v` graph
-- **downloads** `p` pause/resume, `s` seed, `v` verify, `m` move, `r` relink, `y` copy full path, `Y` copy magnet, `x` remove, `d` delete data, `o` reveal in Finder (macOS)
+- **downloads** `p` pause/resume, `s` seed, `v` fully verify completed data, `m` move, `r` relink, `y` copy full path, `Y` copy magnet, `x` remove, `d` delete data, `o` reveal in Finder (macOS)
 - `tab` cycle, `esc` back, `^c` quit
+
+Verification rehashes completed torrent pieces. Direct downloads require a published SHA256; mismatches are moved aside as `.corrupt`, `.corrupt.1`, and so on before retrying.
 
 ## Autopilot (WIP)
 

--- a/internal/engine/direct.go
+++ b/internal/engine/direct.go
@@ -33,12 +33,13 @@ type directItem struct {
 	downloadDir string
 	dataPath    string
 
-	length  int64 // total bytes; 0 until the server reports it
-	done    int64
-	state   TorrentState
-	note    string             // short human status, e.g. a checksum failure
-	cancel  context.CancelFunc // nil while paused
-	samples ring
+	length       int64 // total bytes; 0 until the server reports it
+	done         int64
+	state        TorrentState
+	note         string             // short human status, e.g. a checksum failure
+	cancel       context.CancelFunc // nil while paused
+	verifyCancel context.CancelFunc
+	samples      ring
 }
 
 // directClient has no overall timeout - an ISO download runs for minutes to
@@ -77,6 +78,10 @@ func (e *Engine) AddDirectWithOptions(url, name, sum string, opts AddOptions) (m
 	if !ok {
 		return metainfo.Hash{}, fmt.Errorf("unsafe file name %q", name)
 	}
+	existingSize, existingDone := int64(0), false
+	if fi, err := os.Stat(dataPath); err == nil && fi.Mode().IsRegular() {
+		existingSize, existingDone = fi.Size(), true
+	}
 	h := directHash(url)
 
 	e.mu.Lock()
@@ -95,6 +100,10 @@ func (e *Engine) AddDirectWithOptions(url, name, sum string, opts AddOptions) (m
 		state: StateDownloading,
 	}
 	e.direct[h] = it
+	if existingDone {
+		it.done, it.length, it.state = existingSize, existingSize, StateDone
+		return h, nil
+	}
 	e.startDirectLocked(it)
 	return h, nil
 }
@@ -127,6 +136,10 @@ func (e *Engine) runDirect(ctx context.Context, it *directItem) {
 	// already on disk from an earlier run (e.g. resumed from state.json)
 	if fi, err := os.Stat(dest); err == nil {
 		e.mu.Lock()
+		if it.state == StateVerifying {
+			e.mu.Unlock()
+			return
+		}
 		it.done, it.length, it.state, it.cancel = fi.Size(), fi.Size(), StateDone, nil
 		e.mu.Unlock()
 		return
@@ -372,4 +385,167 @@ func (e *Engine) removeDirect(h metainfo.Hash, it *directItem, deleteData bool) 
 		return err1
 	}
 	return nil
+}
+
+func (e *Engine) verifyDirectDownload(ctx context.Context, h metainfo.Hash) (result VerifyResult, err error) {
+	e.mu.Lock()
+	if e.closing {
+		e.mu.Unlock()
+		return result, errors.New("engine is closing")
+	}
+	it, ok := e.direct[h]
+	if !ok {
+		e.mu.Unlock()
+		return result, errors.New("unknown download")
+	}
+	if it.state == StateVerifying {
+		e.mu.Unlock()
+		return result, ErrVerificationInProgress
+	}
+	if it.state != StateDone {
+		e.mu.Unlock()
+		return result, ErrVerificationIncomplete
+	}
+	expected := strings.TrimSpace(strings.ToLower(it.sha256))
+	if expected == "" {
+		e.mu.Unlock()
+		return result, ErrNoChecksum
+	}
+	dest := it.dataPath
+	if dest == "" {
+		dest, ok = safeDataPath(it.downloadDir, it.name)
+		if !ok {
+			e.mu.Unlock()
+			return result, errors.New("download path is unavailable")
+		}
+	}
+	e.mu.Unlock()
+
+	fi, err := os.Stat(dest)
+	if err != nil {
+		return result, err
+	}
+	if !fi.Mode().IsRegular() {
+		return result, fmt.Errorf("verify %s: not a regular file", dest)
+	}
+
+	e.mu.Lock()
+	current, ok := e.direct[h]
+	if !ok || current != it {
+		e.mu.Unlock()
+		return result, errors.New("download changed during verification")
+	}
+	if it.state == StateVerifying {
+		e.mu.Unlock()
+		return result, ErrVerificationInProgress
+	}
+	if it.state != StateDone {
+		e.mu.Unlock()
+		return result, ErrVerificationIncomplete
+	}
+	if it.cancel != nil {
+		it.cancel()
+		it.cancel = nil
+	}
+	previousDone, previousLength, previousNote := it.done, it.length, it.note
+	verifyCtx, cancel := context.WithCancel(ctx)
+	it.state = StateVerifying
+	it.note = "checking SHA256"
+	it.verifyCancel = cancel
+	e.vwg.Add(1)
+	e.mu.Unlock()
+
+	defer func() {
+		cancel()
+		e.mu.Lock()
+		if current, exists := e.direct[h]; exists && current == it {
+			if it.state == StateVerifying {
+				it.done, it.length, it.state = previousDone, previousLength, StateDone
+				it.note = previousNote
+			}
+			it.verifyCancel = nil
+		}
+		e.mu.Unlock()
+		e.vwg.Done()
+	}()
+
+	return e.verifyDirectFile(verifyCtx, h, it, dest, expected, fi.Size())
+}
+
+func (e *Engine) verifyDirectFile(ctx context.Context, h metainfo.Hash, it *directItem, dest, expected string, size int64) (VerifyResult, error) {
+	var result VerifyResult
+	f, err := os.Open(dest)
+	if err != nil {
+		return result, err
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	buf := make([]byte, 128<<10)
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if _, err := hasher.Write(buf[:n]); err != nil {
+				return result, err
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return result, readErr
+		}
+	}
+
+	got := hex.EncodeToString(hasher.Sum(nil))
+	if got == expected {
+		e.mu.Lock()
+		if current, ok := e.direct[h]; ok && current == it {
+			it.done, it.length, it.state = size, size, StateDone
+			it.note = ""
+		}
+		e.mu.Unlock()
+		return result, nil
+	}
+
+	quarantine, err := nextQuarantinePath(dest)
+	if err != nil {
+		return result, err
+	}
+	if err := os.Rename(dest, quarantine); err != nil {
+		return result, fmt.Errorf("quarantine corrupt download: %w", err)
+	}
+
+	result.ChecksumMismatch = true
+	result.NeedsRepair = true
+	result.QuarantinePath = quarantine
+	e.mu.Lock()
+	if current, ok := e.direct[h]; ok && current == it {
+		it.done, it.length, it.state, it.cancel = 0, size, StatePaused, nil
+		it.note = "checksum mismatch - moved to " + filepath.Base(quarantine) + "; press p to retry"
+	}
+	e.mu.Unlock()
+	return result, nil
+}
+
+func nextQuarantinePath(dest string) (string, error) {
+	base := dest + ".corrupt"
+	for i := 0; ; i++ {
+		candidate := base
+		if i > 0 {
+			candidate = fmt.Sprintf("%s.%d", base, i)
+		}
+		_, err := os.Lstat(candidate)
+		switch {
+		case os.IsNotExist(err):
+			return candidate, nil
+		case err != nil:
+			return "", err
+		}
+	}
 }

--- a/internal/engine/direct_test.go
+++ b/internal/engine/direct_test.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -191,5 +193,154 @@ func TestAddDirectRejectsUnsafeName(t *testing.T) {
 	eng := newDirectTestEngine(t)
 	if _, err := eng.AddDirect("https://example.com/x.iso", "../../evil.iso", ""); err == nil {
 		t.Fatal("expected a path-traversal name to be rejected")
+	}
+}
+
+func TestVerifyDirectAcceptsValidCompletedFile(t *testing.T) {
+	payload := []byte("completed direct download")
+	ts := serveISO(t, payload, nil)
+	eng := newDirectTestEngine(t)
+
+	h, err := eng.AddDirect(ts.URL+"/image.iso", "image.iso", sumHex(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	awaitDirect(t, eng, func(s Snapshot) bool { return s.Hash == h && s.State == StateDone }, 10*time.Second)
+
+	result, err := eng.Verify(context.Background(), h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.NeedsRepair || result.ChecksumMismatch {
+		t.Fatalf("Verify result = %+v, want valid", result)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State != StateDone {
+		t.Fatalf("snapshot = %+v, ok=%v; want done", snap, ok)
+	}
+}
+
+func TestVerifyDirectRecognizesPersistedFileSynchronously(t *testing.T) {
+	payload := []byte("persisted direct download")
+	eng := newDirectTestEngine(t)
+	dest := filepath.Join(eng.cfg.DownloadDir, "image.iso")
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := eng.AddDirect("https://example.invalid/image.iso", "image.iso", sumHex(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State != StateDone {
+		t.Fatalf("snapshot immediately after activation = %+v, ok=%v; want done", snap, ok)
+	}
+	if _, err := eng.Verify(context.Background(), h); err != nil {
+		t.Fatalf("verify persisted file: %v", err)
+	}
+}
+
+func TestVerifyDirectQuarantinesMismatchWithoutOverwritingExistingQuarantine(t *testing.T) {
+	payload := []byte("known-good direct download")
+	ts := serveISO(t, payload, nil)
+	eng := newDirectTestEngine(t)
+
+	h, err := eng.AddDirect(ts.URL+"/image.iso", "image.iso", sumHex(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	awaitDirect(t, eng, func(s Snapshot) bool { return s.Hash == h && s.State == StateDone }, 10*time.Second)
+	dest := filepath.Join(eng.cfg.DownloadDir, "image.iso")
+	if err := os.WriteFile(dest, []byte("corrupt"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest+".corrupt", []byte("older corrupt copy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := eng.Verify(context.Background(), h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.NeedsRepair || !result.ChecksumMismatch || result.QuarantinePath != dest+".corrupt.1" {
+		t.Fatalf("Verify result = %+v", result)
+	}
+	if got, err := os.ReadFile(result.QuarantinePath); err != nil || string(got) != "corrupt" {
+		t.Fatalf("quarantine = %q, err=%v", got, err)
+	}
+	if got, err := os.ReadFile(dest + ".corrupt"); err != nil || string(got) != "older corrupt copy" {
+		t.Fatalf("existing quarantine changed: %q, err=%v", got, err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("original corrupt path still exists: %v", err)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State != StatePaused || snap.BytesCompleted != 0 || !strings.Contains(snap.Note, "checksum mismatch") {
+		t.Fatalf("snapshot = %+v, ok=%v; want paused checksum failure", snap, ok)
+	}
+}
+
+func TestVerifyDirectRequiresChecksum(t *testing.T) {
+	payload := []byte("unverified direct download")
+	ts := serveISO(t, payload, nil)
+	eng := newDirectTestEngine(t)
+
+	h, err := eng.AddDirect(ts.URL+"/image.iso", "image.iso", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	awaitDirect(t, eng, func(s Snapshot) bool { return s.Hash == h && s.State == StateDone }, 10*time.Second)
+	if _, err := eng.Verify(context.Background(), h); !errors.Is(err, ErrNoChecksum) {
+		t.Fatalf("Verify error = %v, want ErrNoChecksum", err)
+	}
+}
+
+func TestVerifyDirectReportsMissingFileWithoutChangingState(t *testing.T) {
+	payload := []byte("completed direct download")
+	ts := serveISO(t, payload, nil)
+	eng := newDirectTestEngine(t)
+
+	h, err := eng.AddDirect(ts.URL+"/image.iso", "image.iso", sumHex(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := awaitDirect(t, eng, func(s Snapshot) bool { return s.Hash == h && s.State == StateDone }, 10*time.Second)
+	if err := os.Remove(filepath.Join(eng.cfg.DownloadDir, "image.iso")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := eng.Verify(context.Background(), h); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Verify error = %v, want missing file", err)
+	}
+	if after, ok := eng.Snapshot(h); !ok || after.State != StateDone || after.BytesCompleted != before.BytesCompleted || after.Length != before.Length {
+		t.Fatalf("snapshot after filesystem error = %+v, ok=%v; want %+v", after, ok, before)
+	}
+}
+
+func TestVerifyDirectHonorsCanceledContext(t *testing.T) {
+	payload := make([]byte, 1<<20)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+	ts := serveISO(t, payload, nil)
+	eng := newDirectTestEngine(t)
+
+	h, err := eng.AddDirect(ts.URL+"/image.iso", "image.iso", sumHex(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	awaitDirect(t, eng, func(s Snapshot) bool { return s.Hash == h && s.State == StateDone }, 10*time.Second)
+	before, _ := eng.Snapshot(h)
+	dest := filepath.Join(eng.cfg.DownloadDir, "image.iso")
+	if err := os.Truncate(dest, int64(len(payload)/2)); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := eng.Verify(ctx, h); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify error = %v, want context.Canceled", err)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State != StateDone || snap.BytesCompleted != before.BytesCompleted || snap.Length != before.Length {
+		t.Fatalf("snapshot = %+v, ok=%v; canceled verification must restore %+v", snap, ok, before)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -37,6 +37,7 @@ const (
 	StateDone
 	StatePaused
 	StateMissing
+	StateVerifying
 )
 
 func (s TorrentState) String() string {
@@ -55,8 +56,27 @@ func (s TorrentState) String() string {
 		return "paused"
 	case StateMissing:
 		return "missing data"
+	case StateVerifying:
+		return "verifying"
 	}
 	return "unknown"
+}
+
+var (
+	ErrVerificationInProgress = errors.New("verification already in progress")
+	ErrVerificationIncomplete = errors.New("verification requires a completed download")
+	ErrNoChecksum             = errors.New("no checksum available for this download")
+)
+
+// VerifyResult describes data-integrity failures separately from operational
+// errors. Bad data is a successful verification result: torrents repair it
+// automatically, while direct downloads are quarantined for an explicit retry.
+type VerifyResult struct {
+	CheckedPieces    int
+	BadPieces        int
+	NeedsRepair      bool
+	ChecksumMismatch bool
+	QuarantinePath   string
 }
 
 // FileInfo describes one file inside a torrent, for the preview screen.
@@ -177,6 +197,8 @@ type item struct {
 	metadataStart  time.Time
 	trackerCount   int
 	samples        ring
+	verifying      bool
+	verifyCancel   context.CancelFunc
 }
 
 type Engine struct {
@@ -188,7 +210,9 @@ type Engine struct {
 	direct  map[metainfo.Hash]*directItem // plain-HTTPS downloads (see direct.go)
 	dwg     sync.WaitGroup                // running direct-download goroutines
 	mwg     sync.WaitGroup                // metadata-ready/cache goroutines
+	vwg     sync.WaitGroup                // manual verification calls
 	pcClose func()                        // bolt piece-completion closer
+	closing bool
 
 	torrentHTTP *http.Client
 	directHTTP  *http.Client
@@ -763,16 +787,22 @@ func (e *Engine) StartDownload(h metainfo.Hash, excluded []int) {
 
 // Pause drops the torrent from the client but keeps its entry; piece
 // completion makes resuming cheap. A direct download keeps its .part file.
-func (e *Engine) Pause(h metainfo.Hash) {
+func (e *Engine) Pause(h metainfo.Hash) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if d, ok := e.direct[h]; ok {
+		if d.state == StateVerifying {
+			return ErrVerificationInProgress
+		}
 		pauseDirectLocked(d)
-		return
+		return nil
 	}
 	it, ok := e.items[h]
 	if !ok || it.paused || it.t == nil {
-		return
+		return nil
+	}
+	if it.verifying {
+		return ErrVerificationInProgress
 	}
 	it.name = displayName(it)
 	it.length = torrentLength(it.t)
@@ -781,6 +811,7 @@ func (e *Engine) Pause(h metainfo.Hash) {
 	it.t = nil
 	it.paused = true
 	it.samples = ring{}
+	return nil
 }
 
 // Resume re-adds a paused torrent, or restarts a paused direct download from
@@ -788,6 +819,10 @@ func (e *Engine) Pause(h metainfo.Hash) {
 func (e *Engine) Resume(h metainfo.Hash) error {
 	e.mu.Lock()
 	if d, ok := e.direct[h]; ok {
+		if d.state == StateVerifying {
+			e.mu.Unlock()
+			return ErrVerificationInProgress
+		}
 		if d.state == StatePaused {
 			e.startDirectLocked(d)
 		}
@@ -798,6 +833,10 @@ func (e *Engine) Resume(h metainfo.Hash) error {
 	if !ok || !it.paused {
 		e.mu.Unlock()
 		return nil
+	}
+	if it.verifying {
+		e.mu.Unlock()
+		return ErrVerificationInProgress
 	}
 	magnet := it.magnet
 	excluded := it.excluded
@@ -810,34 +849,38 @@ func (e *Engine) Resume(h metainfo.Hash) error {
 
 // SetSeeding toggles uploading for a torrent by capping its connections.
 // Direct downloads have nothing to seed; the toggle is inert for them.
-func (e *Engine) SetSeeding(h metainfo.Hash, on bool) {
+func (e *Engine) SetSeeding(h metainfo.Hash, on bool) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	it, ok := e.items[h]
 	if !ok {
-		return
+		return nil
+	}
+	if it.verifying {
+		return ErrVerificationInProgress
 	}
 	it.seeding = on
 	if it.t == nil {
-		return
+		return nil
 	}
 	if on {
-		max := e.cfg.MaxConnections
-		if max <= 0 {
-			max = 50
-		}
-		it.t.SetMaxEstablishedConns(max)
+		it.t.SetMaxEstablishedConns(e.maxTorrentConnections())
 		it.noSeedApplied = false
 	} else {
 		it.t.SetMaxEstablishedConns(0)
 		it.noSeedApplied = true
 	}
+	return nil
 }
 
 // Remove drops the torrent and forgets it; optionally deletes downloaded data.
 func (e *Engine) Remove(h metainfo.Hash, deleteData bool) error {
 	e.mu.Lock()
 	if d, ok := e.direct[h]; ok {
+		if d.state == StateVerifying {
+			e.mu.Unlock()
+			return ErrVerificationInProgress
+		}
 		e.mu.Unlock()
 		return e.removeDirect(h, d, deleteData)
 	}
@@ -845,6 +888,10 @@ func (e *Engine) Remove(h metainfo.Hash, deleteData bool) error {
 	if !ok {
 		e.mu.Unlock()
 		return nil
+	}
+	if it.verifying {
+		e.mu.Unlock()
+		return ErrVerificationInProgress
 	}
 	var dataPath string
 	if deleteData {
@@ -867,6 +914,177 @@ func (e *Engine) Remove(h metainfo.Hash, deleteData bool) error {
 		return os.RemoveAll(dataPath)
 	}
 	return nil
+}
+
+// Verify re-hashes a completed download. Torrent hash failures are marked
+// incomplete by anacrolix and are made downloadable again before this method
+// returns. Direct checksum mismatches are quarantined and left paused for an
+// explicit retry. Bad data is reported in VerifyResult rather than as an error.
+func (e *Engine) Verify(ctx context.Context, h metainfo.Hash) (result VerifyResult, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	e.mu.Lock()
+	if e.closing {
+		e.mu.Unlock()
+		return result, errors.New("engine is closing")
+	}
+	if _, ok := e.direct[h]; ok {
+		e.mu.Unlock()
+		return e.verifyDirectDownload(ctx, h)
+	}
+	it, ok := e.items[h]
+	if !ok {
+		e.mu.Unlock()
+		return result, errors.New("unknown download")
+	}
+	if it.verifying {
+		e.mu.Unlock()
+		return result, ErrVerificationInProgress
+	}
+	if it.paused || it.t == nil {
+		e.mu.Unlock()
+		return result, ErrVerificationIncomplete
+	}
+	t := it.t
+	verifyCtx, cancel := context.WithCancel(ctx)
+	var badPieceIndexes []int
+	it.verifying = true
+	it.verifyCancel = cancel
+	e.vwg.Add(1)
+	e.mu.Unlock()
+
+	defer func() {
+		cancel()
+		e.mu.Lock()
+		if current, exists := e.items[h]; exists && current == it {
+			it.verifying = false
+			it.verifyCancel = nil
+			if result.NeedsRepair && it.t == t {
+				t.SetMaxEstablishedConns(e.maxTorrentConnections())
+				if spec, err := torrent.TorrentSpecFromMagnetUri(it.magnet); err == nil {
+					peers := make([]torrent.PeerInfo, 0, len(spec.PeerAddrs))
+					for _, addr := range spec.PeerAddrs {
+						peers = append(peers, torrent.PeerInfo{Addr: torrent.StringAddr(addr), Source: torrent.PeerSourceDirect, Trusted: true})
+					}
+					t.AddPeers(peers)
+				}
+				for _, index := range badPieceIndexes {
+					t.Piece(index).SetPriority(torrent.PiecePriorityNow)
+				}
+				it.noSeedApplied = false
+			}
+		}
+		e.mu.Unlock()
+		e.vwg.Done()
+	}()
+
+	select {
+	case <-verifyCtx.Done():
+		return result, verifyCtx.Err()
+	case <-t.Closed():
+		return result, errors.New("torrent closed during verification")
+	case <-t.GotInfo():
+	}
+	if t.Info() == nil {
+		return result, errors.New("torrent metadata unavailable")
+	}
+
+	e.mu.Lock()
+	if current, exists := e.items[h]; !exists || current != it || it.t != t {
+		e.mu.Unlock()
+		return result, errors.New("download changed during verification")
+	}
+	length := effectiveLength(it)
+	done := t.BytesCompleted()
+	excluded := append([]int(nil), it.excluded...)
+	e.mu.Unlock()
+	if length <= 0 || done < length {
+		return result, ErrVerificationIncomplete
+	}
+
+	desired := make([]bool, int(t.NumPieces()))
+	excludedSet := make(map[int]bool, len(excluded))
+	for _, index := range excluded {
+		excludedSet[index] = true
+	}
+	for fileIndex, file := range t.Files() {
+		if excludedSet[fileIndex] {
+			continue
+		}
+		for pieceIndex := file.BeginPieceIndex(); pieceIndex < file.EndPieceIndex(); pieceIndex++ {
+			desired[pieceIndex] = true
+		}
+	}
+	var pieces []int
+	for i := 0; i < int(t.NumPieces()); i++ {
+		if !desired[i] {
+			continue
+		}
+		state := t.PieceState(i)
+		if !state.Complete || state.Hashing || state.QueuedForHash || state.Marking {
+			return result, ErrVerificationIncomplete
+		}
+		pieces = append(pieces, i)
+	}
+	if len(pieces) == 0 {
+		return result, ErrVerificationIncomplete
+	}
+
+	for _, index := range pieces {
+		state, err := verifyTorrentPiece(verifyCtx, t, index)
+		if err != nil {
+			return result, fmt.Errorf("verify piece %d: %w", index, err)
+		}
+		result.CheckedPieces++
+		if !state.Complete {
+			result.BadPieces++
+			result.NeedsRepair = true
+			badPieceIndexes = append(badPieceIndexes, index)
+		}
+	}
+
+	e.mu.Lock()
+	if current, exists := e.items[h]; exists && current == it && it.t == t {
+		length = effectiveLength(it)
+		done = t.BytesCompleted()
+	}
+	e.mu.Unlock()
+	if length > 0 && done < length {
+		result.NeedsRepair = true
+	}
+	return result, nil
+}
+
+func verifyTorrentPiece(ctx context.Context, t *torrent.Torrent, index int) (torrent.PieceState, error) {
+	sub := t.SubscribePieceStateChanges()
+	defer sub.Close()
+	if err := t.Piece(index).VerifyDataContext(ctx); err != nil {
+		return torrent.PieceState{}, err
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return torrent.PieceState{}, ctx.Err()
+		case <-t.Closed():
+			return torrent.PieceState{}, errors.New("torrent closed")
+		case change, ok := <-sub.Values:
+			if !ok {
+				return torrent.PieceState{}, errors.New("piece-state subscription closed")
+			}
+			if change.Index == index && !change.Hashing && !change.QueuedForHash && !change.Marking {
+				return change.PieceState, nil
+			}
+		}
+	}
+}
+
+func (e *Engine) maxTorrentConnections() int {
+	if e.cfg.MaxConnections > 0 {
+		return e.cfg.MaxConnections
+	}
+	return 50
 }
 
 // safeDataPath resolves a torrent's data path under dir, refusing anything that
@@ -1007,6 +1225,11 @@ func (e *Engine) snapshot(h metainfo.Hash, it *item, now time.Time) Snapshot {
 
 	it.samples.push(sample{at: now, bytes: s.BytesCompleted})
 	s.SpeedBps = it.samples.speedBps()
+	if it.verifying {
+		s.State = StateVerifying
+		s.Note = "checking completed pieces"
+		return s
+	}
 
 	switch {
 	case t.Info() == nil:
@@ -1047,14 +1270,24 @@ func (e *Engine) ListenPort() int { return e.client.LocalPort() }
 // stopping direct downloads (their .part files resume on next start).
 func (e *Engine) Close() {
 	e.mu.Lock()
+	e.closing = true
 	for _, d := range e.direct {
 		if d.cancel != nil {
 			d.cancel()
 			d.cancel = nil
 		}
+		if d.verifyCancel != nil {
+			d.verifyCancel()
+		}
+	}
+	for _, it := range e.items {
+		if it.verifyCancel != nil {
+			it.verifyCancel()
+		}
 	}
 	e.mu.Unlock()
 	e.dwg.Wait()
+	e.vwg.Wait()
 
 	e.client.Close()
 	<-e.client.Closed()

--- a/internal/engine/engine_integration_test.go
+++ b/internal/engine/engine_integration_test.go
@@ -1,7 +1,10 @@
 package engine
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -96,7 +99,8 @@ func TestEngineDownloadsFromLocalSeeder(t *testing.T) {
 
 	magnet := fmt.Sprintf("magnet:?xt=urn:btih:%s&x.pe=127.0.0.1:%d",
 		mi.HashInfoBytes().HexString(), seederPort)
-	h, err := eng.Add(magnet, nil)
+	seed := false
+	h, err := eng.AddWithOptions(magnet, AddOptions{Seed: &seed})
 	if err != nil {
 		eng.Close()
 		t.Fatal(err)
@@ -110,6 +114,47 @@ func TestEngineDownloadsFromLocalSeeder(t *testing.T) {
 	if err != nil || len(got) != len(payload) {
 		eng.Close()
 		t.Fatalf("downloaded file: %d bytes, err=%v; want %d bytes", len(got), err, len(payload))
+	}
+
+	validResult, err := eng.Verify(context.Background(), h)
+	if err != nil {
+		eng.Close()
+		t.Fatalf("verify valid torrent: %v", err)
+	}
+	if validResult.CheckedPieces == 0 || validResult.BadPieces != 0 || validResult.NeedsRepair {
+		eng.Close()
+		t.Fatalf("valid Verify result = %+v", validResult)
+	}
+
+	payloadPath := filepath.Join(cfg.DownloadDir, "payload.dat")
+	// Repeat the non-seeding recovery transition so peer reconnection and piece
+	// reprioritization are exercised after every completed repair.
+	for attempt := 0; attempt < 5; attempt++ {
+		corrupt := append([]byte(nil), payload...)
+		corrupt[(attempt+1)*(len(corrupt)/6)] ^= 0xff
+		if err := os.Chmod(payloadPath, 0o644); err != nil {
+			eng.Close()
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(payloadPath, corrupt, 0o644); err != nil {
+			eng.Close()
+			t.Fatal(err)
+		}
+		badResult, err := eng.Verify(context.Background(), h)
+		if err != nil {
+			eng.Close()
+			t.Fatalf("verify corrupt torrent (attempt %d): %v", attempt, err)
+		}
+		if badResult.BadPieces == 0 || !badResult.NeedsRepair {
+			eng.Close()
+			t.Fatalf("corrupt Verify result (attempt %d) = %+v", attempt, badResult)
+		}
+		awaitComplete(t, eng, h, 60*time.Second)
+		repaired, err := os.ReadFile(payloadPath)
+		if err != nil || !bytes.Equal(repaired, payload) {
+			eng.Close()
+			t.Fatalf("repaired payload differs on attempt %d, err=%v", attempt, err)
+		}
 	}
 	eng.Close() // releases the bolt piece-completion lock
 
@@ -156,6 +201,56 @@ func TestAddWithOptionsRecordsDownloadDir(t *testing.T) {
 	}
 	if snap.DownloadDir != dir {
 		t.Fatalf("DownloadDir = %q, want %q", snap.DownloadDir, dir)
+	}
+}
+
+func TestVerifyWaitsForMetadataAndHonorsContext(t *testing.T) {
+	cfg := strictProxyConfig(t, "127.0.0.1:1")
+	eng, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	h, err := eng.Add("magnet:?xt=urn:btih:"+strings.Repeat("b", 40), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	verifyErr := make(chan error, 1)
+	go func() {
+		_, err := eng.Verify(ctx, h)
+		verifyErr <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if snap, ok := eng.Snapshot(h); ok && snap.State == StateVerifying {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("verification did not enter verifying state")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := eng.Verify(context.Background(), h); !errors.Is(err, ErrVerificationInProgress) {
+		t.Fatalf("duplicate Verify error = %v, want ErrVerificationInProgress", err)
+	}
+	if err := eng.Pause(h); !errors.Is(err, ErrVerificationInProgress) {
+		t.Fatalf("Pause error = %v, want ErrVerificationInProgress", err)
+	}
+	if err := eng.SetSeeding(h, true); !errors.Is(err, ErrVerificationInProgress) {
+		t.Fatalf("SetSeeding error = %v, want ErrVerificationInProgress", err)
+	}
+	if err := eng.Remove(h, false); !errors.Is(err, ErrVerificationInProgress) {
+		t.Fatalf("Remove error = %v, want ErrVerificationInProgress", err)
+	}
+	cancel()
+	if err := <-verifyErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Verify error = %v, want context canceled", err)
+	}
+	if snap, ok := eng.Snapshot(h); !ok || snap.State != StateFetchingMeta {
+		t.Fatalf("snapshot = %+v, ok=%v; want metadata fetch restored", snap, ok)
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -46,10 +46,13 @@ type App struct {
 	proxyCheck proxyChecker
 	startup    tea.Cmd // optional one-shot action requested on the command line
 
-	errText      string
-	yanked       string    // field just copied ("path", "magnet"); drives the toast
-	yankGen      int       // invalidates stale toast-clear timers when yanks overlap
-	lastTickSave time.Time // throttles progress-only state.json writes on the tick
+	errText          string
+	yanked           string // field just copied ("path", "magnet"); drives the toast
+	yankGen          int    // invalidates stale toast-clear timers when yanks overlap
+	verifyNotice     string
+	verifyNoticeWarn bool
+	verifyNoticeGen  int
+	lastTickSave     time.Time // throttles progress-only state.json writes on the tick
 }
 
 func New(cfg *config.Config, eng *engine.Engine, agg *aggregator.Aggregator, st *state.State, hs *health.Store) *App {
@@ -166,6 +169,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case healthDoneMsg:
 		return a, a.onHealthDone(msg)
 
+	case verifyDoneMsg:
+		return a, a.onVerifyDone(msg)
+
+	case clearVerifyNoticeMsg:
+		if msg.gen == a.verifyNoticeGen {
+			a.verifyNotice = ""
+		}
+		return a, nil
+
 	case proxyCheckMsg:
 		a.onProxyCheck(msg)
 		return a, nil
@@ -212,7 +224,7 @@ func (a *App) tickShouldContinue() bool {
 	}
 	for _, s := range a.downloads.snaps {
 		switch s.State {
-		case engine.StateFetchingMeta, engine.StatePreviewing, engine.StateDownloading, engine.StateSeeding:
+		case engine.StateFetchingMeta, engine.StatePreviewing, engine.StateDownloading, engine.StateSeeding, engine.StateVerifying:
 			return true
 		}
 	}

--- a/internal/tui/downloads.go
+++ b/internal/tui/downloads.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -110,6 +111,12 @@ func (a *App) updateDownloads(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	items := a.downloadItems()
 	rows := a.downloadListRows()
+	if verificationBlocksKey(key.String()) {
+		if it, ok := a.selectedDownload(items); ok && it.State == engine.StateVerifying {
+			a.errText = "verification in progress"
+			return a, clearErrCmd()
+		}
+	}
 	switch key.String() {
 	case "q":
 		return a, tea.Quit
@@ -178,6 +185,15 @@ func (a *App) updateDownloads(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+func verificationBlocksKey(key string) bool {
+	switch key {
+	case "p", "s", "v", "m", "r", "x", "d":
+		return true
+	default:
+		return false
+	}
+}
+
 func yankDownloadValue(what, value string) tea.Cmd {
 	return func() tea.Msg {
 		text := strings.TrimSpace(value)
@@ -232,6 +248,17 @@ func revealDownload(it downloadItem) tea.Cmd {
 // after a copy lands on the clipboard.
 func yankToast(what string) string {
 	return styleYankBox.Render(styleBrand.Render("yanked ") + styleDim.Render(what))
+}
+
+func verifyNoticeToast(message string, warn bool) string {
+	color := colBrand
+	textStyle := styleOK
+	if warn {
+		color = colAmber
+		textStyle = styleBest
+	}
+	box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(color).Padding(0, 2)
+	return box.Render(textStyle.Render(message))
 }
 
 // overlayBottomRight splices toast into base's bottom-right corner, keeping
@@ -421,7 +448,10 @@ func (a *App) toggleSeed(it downloadItem) tea.Cmd {
 	}
 	next := !it.Seed
 	if it.Live {
-		a.eng.SetSeeding(it.Hash, next)
+		if err := a.eng.SetSeeding(it.Hash, next); err != nil {
+			a.errText = "seed change failed: " + err.Error()
+			return clearErrCmd()
+		}
 		a.downloads.snaps = a.eng.Snapshots()
 	}
 	if e := a.st.Find(it.Magnet); e != nil {
@@ -437,7 +467,10 @@ func (a *App) togglePause(it downloadItem) tea.Cmd {
 		return clearErrCmd()
 	}
 	if it.Live && it.State != engine.StatePaused {
-		a.eng.Pause(it.Hash)
+		if err := a.eng.Pause(it.Hash); err != nil {
+			a.errText = "pause failed: " + err.Error()
+			return clearErrCmd()
+		}
 		if e := a.st.Find(it.Magnet); e != nil {
 			e.Paused = true
 		}
@@ -448,57 +481,129 @@ func (a *App) togglePause(it downloadItem) tea.Cmd {
 		a.errText = "resume failed: " + err.Error()
 		return clearErrCmd()
 	}
-	if e := a.st.Find(it.Magnet); e != nil {
-		e.Paused = false
+	if a.st != nil {
+		if e := a.st.Find(it.Magnet); e != nil {
+			e.Paused = false
+		}
 	}
 	a.downloads.snaps = a.eng.Snapshots()
 	return tea.Batch(a.saveState(), a.ensureTick())
 }
 
 func (a *App) verifyDownload(it downloadItem) tea.Cmd {
-	if it.State == engine.StateMissing {
+	switch it.State {
+	case engine.StateVerifying:
+		a.errText = "verification already in progress"
+		return clearErrCmd()
+	case engine.StateMissing:
 		a.errText = "missing data - relink to existing files first"
 		return clearErrCmd()
+	case engine.StateDone, engine.StateSeeding:
+	default:
+		a.errText = "verification is available after the download completes"
+		return clearErrCmd()
 	}
-	if it.Live {
-		if err := a.eng.Remove(it.Hash, false); err != nil {
+
+	h := it.Hash
+	if !it.Live {
+		var err error
+		h, err = a.activateDownload(it)
+		if err != nil {
 			a.errText = "verify failed: " + err.Error()
 			return clearErrCmd()
 		}
 	}
-	if err := a.resumeDownload(it); err != nil {
-		a.errText = "verify failed: " + err.Error()
-		return clearErrCmd()
-	}
-	if e := a.st.Find(it.Magnet); e != nil {
-		e.Paused = false
+	if a.st != nil {
+		if e := a.st.Find(it.Magnet); e != nil {
+			e.Paused = false
+		}
 	}
 	a.downloads.snaps = a.eng.Snapshots()
-	return tea.Batch(a.saveState(), a.ensureTick())
+	magnet := it.Magnet
+	return tea.Batch(a.saveState(), a.ensureTick(), func() tea.Msg {
+		result, err := a.eng.Verify(context.Background(), h)
+		return verifyDoneMsg{hash: h, magnet: magnet, result: result, err: err}
+	})
+}
+
+func (a *App) onVerifyDone(msg verifyDoneMsg) tea.Cmd {
+	a.downloads.snaps = a.eng.Snapshots()
+	var save tea.Cmd
+	if a.st != nil {
+		if entry := a.st.Find(msg.magnet); entry != nil && applyVerifyResultToEntry(entry, msg.result) {
+			save = a.saveState()
+		}
+	}
+	if msg.err != nil {
+		a.verifyNotice = ""
+		a.errText = "verify failed: " + msg.err.Error()
+		return tea.Batch(save, a.ensureTick(), clearErrCmd())
+	}
+
+	a.verifyNotice, a.verifyNoticeWarn = verificationNotice(msg.result)
+	a.verifyNoticeGen++
+	return tea.Batch(save, a.ensureTick(), clearVerifyNoticeCmd(a.verifyNoticeGen))
+}
+
+func applyVerifyResultToEntry(entry *state.Entry, result engine.VerifyResult) bool {
+	if !result.NeedsRepair && !result.ChecksumMismatch {
+		return false
+	}
+	changed := entry.Done || entry.CompletedAt != nil || entry.Paused != result.ChecksumMismatch
+	entry.Done = false
+	entry.CompletedAt = nil
+	entry.Paused = result.ChecksumMismatch
+	if result.ChecksumMismatch && entry.BytesCompleted != 0 {
+		entry.BytesCompleted = 0
+		changed = true
+	}
+	return changed
+}
+
+func verificationNotice(result engine.VerifyResult) (string, bool) {
+	switch {
+	case result.ChecksumMismatch:
+		return "checksum failed - moved to " + filepath.Base(result.QuarantinePath), true
+	case result.BadPieces == 1:
+		return "1 bad piece - redownloading", true
+	case result.BadPieces > 1:
+		return fmt.Sprintf("%d bad pieces - redownloading", result.BadPieces), true
+	case result.NeedsRepair:
+		return "incomplete data found - redownloading", true
+	default:
+		return "verified - all data is valid", false
+	}
 }
 
 func (a *App) resumeDownload(it downloadItem) error {
+	_, err := a.activateDownload(it)
+	return err
+}
+
+func (a *App) activateDownload(it downloadItem) (metainfo.Hash, error) {
 	downloadDir := it.DownloadDir
 	if downloadDir == "" {
 		downloadDir = a.cfg.DownloadDir
 	}
 	seed := it.Seed
 	opts := engine.AddOptions{DownloadDir: downloadDir, Seed: &seed}
-	if e := a.st.Find(it.Magnet); e != nil {
-		opts.Excluded = e.Excluded
+	if a.st != nil {
+		if e := a.st.Find(it.Magnet); e != nil {
+			opts.Excluded = e.Excluded
+		}
 	}
 	if strings.HasPrefix(it.Magnet, "http://") || strings.HasPrefix(it.Magnet, "https://") {
 		name := it.Name
 		sum := ""
-		if e := a.st.Find(it.Magnet); e != nil {
-			name = e.Name
-			sum = e.SHA256
+		if a.st != nil {
+			if e := a.st.Find(it.Magnet); e != nil {
+				name = e.Name
+				sum = e.SHA256
+			}
 		}
-		_, err := a.eng.AddDirectWithOptions(it.Magnet, name, sum, opts)
-		return err
+		return a.eng.AddDirectWithOptions(it.Magnet, name, sum, opts)
 	}
-	_, err := a.eng.AddWithOptions(it.Magnet, opts)
-	return err
+	return a.eng.AddWithOptions(it.Magnet, opts)
 }
 
 func (a *App) removeDownload(it downloadItem, deleteData bool) error {
@@ -734,7 +839,9 @@ func (a *App) viewDownloads() string {
 		help = d.prompt.input.View()
 	}
 	body := b.String()
-	if a.yanked != "" {
+	if a.verifyNotice != "" {
+		body = overlayBottomRight(padLines(body, a.bodyHeight()), verifyNoticeToast(a.verifyNotice, a.verifyNoticeWarn), width)
+	} else if a.yanked != "" {
 		body = overlayBottomRight(padLines(body, a.bodyHeight()), yankToast(a.yanked), width)
 	}
 	return a.chrome(a.downloadsContext(items), body, help)
@@ -837,6 +944,8 @@ func stateBadge(s engine.TorrentState) string {
 		return styleFaint.Render(s.String())
 	case engine.StateMissing:
 		return styleErr.Render(s.String())
+	case engine.StateVerifying:
+		return styleBest.Render(s.String())
 	case engine.StateFetchingMeta, engine.StatePreviewing:
 		return styleDim.Render(s.String())
 	}

--- a/internal/tui/downloads_test.go
+++ b/internal/tui/downloads_test.go
@@ -1,12 +1,17 @@
 package tui
 
 import (
+	"context"
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/anacrolix/torrent/metainfo"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/melqtx/tork/internal/config"
 	"github.com/melqtx/tork/internal/engine"
 	"github.com/melqtx/tork/internal/state"
@@ -121,5 +126,124 @@ func TestOverlayBottomRightKeepsLeftContent(t *testing.T) {
 	}
 	if !strings.HasPrefix(got[4], "ee") || !strings.HasSuffix(got[4], "YY") {
 		t.Fatalf("toast row 2 = %q, want left content kept and YY right-aligned", got[4])
+	}
+}
+
+func TestVerificationGuardsDoNotPersistRefusedPauseOrSeed(t *testing.T) {
+	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	magnet := "magnet:?xt=urn:btih:" + strings.Repeat("c", 40)
+	h, err := eng.Add(magnet, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	verifyErr := make(chan error, 1)
+	go func() {
+		_, err := eng.Verify(ctx, h)
+		verifyErr <- err
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if snap, ok := eng.Snapshot(h); ok && snap.State == engine.StateVerifying {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("verification did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	st := &state.State{}
+	st.Upsert(state.Entry{Magnet: magnet, Seed: state.Bool(false)})
+	app := &App{cfg: cfg, eng: eng, st: st}
+	stale := downloadItem{Hash: h, Magnet: magnet, State: engine.StateDone, Live: true}
+	app.togglePause(stale)
+	if st.Entries[0].Paused || !strings.Contains(app.errText, "verification") {
+		t.Fatalf("pause guard persisted=%v err=%q", st.Entries[0].Paused, app.errText)
+	}
+	app.toggleSeed(stale)
+	if *st.Entries[0].Seed || !strings.Contains(app.errText, "verification") {
+		t.Fatalf("seed guard persisted=%v err=%q", *st.Entries[0].Seed, app.errText)
+	}
+	cancel()
+	<-verifyErr
+}
+
+func TestVerifyPersistedDirectUsesActivatedHashAndShowsResult(t *testing.T) {
+	t.Setenv("XDG_DOWNLOAD_DIR", filepath.Join(t.TempDir(), "Downloads"))
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), ".tork"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := engine.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	payload := []byte("persisted ISO")
+	if err := os.MkdirAll(cfg.DownloadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(cfg.DownloadDir, "image.iso")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	url := "https://example.invalid/image.iso"
+	st := &state.State{}
+	st.Upsert(state.Entry{Magnet: url, Name: "image.iso", SHA256: fmt.Sprintf("%x", sha256.Sum256(payload)), Done: true, DownloadDir: cfg.DownloadDir, DataPath: path})
+	app := New(cfg, eng, nil, st, nil)
+	it := app.itemFromEntry(&st.Entries[0], 0)
+	cmd := app.verifyDownload(it)
+	if cmd == nil {
+		t.Fatal("verify command is nil")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("verify command message = %T, want tea.BatchMsg", msg)
+	}
+	var done verifyDoneMsg
+	found := false
+	for _, child := range batch {
+		if msg := child(); msg != nil {
+			if verifyMsg, ok := msg.(verifyDoneMsg); ok {
+				done, found = verifyMsg, true
+			}
+		}
+	}
+	if !found || done.err != nil || done.hash == (metainfo.Hash{}) {
+		t.Fatalf("verify result found=%v msg=%+v", found, done)
+	}
+	app.onVerifyDone(done)
+	if app.verifyNotice != "verified - all data is valid" || app.verifyNoticeWarn {
+		t.Fatalf("verify notice=%q warn=%v", app.verifyNotice, app.verifyNoticeWarn)
+	}
+}
+
+func TestApplyVerifyResultClearsCompletionState(t *testing.T) {
+	now := time.Now()
+	entry := state.Entry{Done: true, Paused: true, BytesCompleted: 42, CompletedAt: &now}
+	if !applyVerifyResultToEntry(&entry, engine.VerifyResult{NeedsRepair: true, BadPieces: 1}) {
+		t.Fatal("torrent repair did not report a state change")
+	}
+	if entry.Done || entry.CompletedAt != nil || entry.Paused || entry.BytesCompleted != 42 {
+		t.Fatalf("torrent repair entry = %+v", entry)
+	}
+	entry.Done, entry.BytesCompleted, entry.CompletedAt = true, 42, &now
+	if !applyVerifyResultToEntry(&entry, engine.VerifyResult{NeedsRepair: true, ChecksumMismatch: true}) {
+		t.Fatal("direct mismatch did not report a state change")
+	}
+	if entry.Done || entry.CompletedAt != nil || !entry.Paused || entry.BytesCompleted != 0 {
+		t.Fatalf("direct mismatch entry = %+v", entry)
 	}
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/melqtx/tork/internal/aggregator"
+	"github.com/melqtx/tork/internal/engine"
 	"github.com/melqtx/tork/internal/provider"
 )
 
@@ -59,6 +60,15 @@ type proxyCheckMsg struct {
 // holds the new snapshot, so only the error travels.
 type healthDoneMsg struct{ err error }
 
+type verifyDoneMsg struct {
+	hash   metainfo.Hash
+	magnet string
+	result engine.VerifyResult
+	err    error
+}
+
+type clearVerifyNoticeMsg struct{ gen int }
+
 // waitForResult pumps one item off the search results channel into the tea
 // loop, then re-arms itself from Update - the idiomatic streaming pattern.
 func waitForResult(ch <-chan provider.Result) tea.Cmd {
@@ -101,4 +111,8 @@ func clearErrCmd() tea.Cmd {
 // confirmation needs less dwell time than an error.
 func clearYankCmd(gen int) tea.Cmd {
 	return tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg { return clearYankMsg{gen: gen} })
+}
+
+func clearVerifyNoticeCmd(gen int) tea.Cmd {
+	return tea.Tick(3*time.Second, func(time.Time) tea.Msg { return clearVerifyNoticeMsg{gen: gen} })
 }


### PR DESCRIPTION
## Summary

- replace the verification no-op with engine-owned, cancellable verification for completed downloads
- verify torrent pieces after metadata is available, block conflicting mutations, and restore repair priorities/connections when corrupt pieces are found
- verify direct downloads with SHA-256 and quarantine mismatches as `.corrupt`, `.corrupt.1`, and so on
- expose verification state and result notices in the TUI
- clear persisted completion state whenever repair is required and preserve recovery across restarts
- verify persisted/non-live entries using the actual hash returned during reactivation
- document completed-download verification behavior

## Root cause and impact

The existing verification action did not perform engine-owned integrity checking or drive damaged downloads back into a recoverable state. Corrupt completed data could therefore remain marked complete, and direct-download mismatches had no safe quarantine path.

This change limits verification to completed downloads, prevents conflicting operations while hashing, and ensures corrupt data is either repaired automatically (torrents) or quarantined safely (direct downloads).

## Validation

Passed locally:

- `go mod verify`
- `go mod tidy -diff`
- `go vet ./...`
- `go build ./...`
- `go test -count=1 -timeout 5m ./...`
- `go test -race -count=1 -timeout 5m ./...`
- `go test -shuffle=on -count=3 -timeout 5m ./...`
- targeted engine verification race tests, 30 repetitions
- targeted TUI verification race tests, 30 repetitions
- torrent corruption/verification/repair integration test, 20 fresh-process race runs with five repair cycles per run (100 cycles)
- Linux amd64, arm64, and riscv64 cross-builds with `CGO_ENABLED=0`

The exact CI `CGO_ENABLED=1 GOARCH=riscv64` build passed in GitHub Actions.

## Stress-test disclosure

Repeated same-process `go test -race -count=N` runs can stall while repeatedly constructing and tearing down local anacrolix seeder/client stacks. The stalls occur during the initial loopback transfer before verification begins. Every verification cycle reached completed successfully, and 20 independent fresh-process race runs passed all 100 corruption/repair cycles. This isolates the observed flake to repeated local torrent stacks in one test process rather than the verification path, but it is disclosed here for review.

## Review focus

Please pay particular attention to:

- operation locking and cancellation during torrent verification
- persisted `Done` / `CompletedAt` recovery transitions
- direct-download mismatch quarantine naming and filesystem failure handling

Fixes #7
